### PR TITLE
Encrypt string pool for JNI registration

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/source/StringPool.java
+++ b/obfuscator/src/main/java/by/radioegor146/source/StringPool.java
@@ -71,15 +71,19 @@ public class StringPool {
     }
 
     public String build() {
-        List<Byte> bytes = new ArrayList<>();
+        List<Integer> bytes = new ArrayList<>();
+        int[] index = {0};
         pool.entrySet().stream()
                 .sorted(Map.Entry.comparingByValue())
                 .map(Map.Entry::getKey)
                 .forEach(string -> {
                     for (byte b : getModifiedUtf8Bytes(string)) {
-                        bytes.add(b);
+                        int key = (index[0] * 0x5A + 0xAC) & 0xFF;
+                        bytes.add(((b ^ key) + 0x33) & 0xFF);
+                        index[0]++;
                     }
-                    bytes.add((byte) 0);
+                    bytes.add(0);
+                    index[0]++;
                 });
 
         String result = String.format("{ %s }", bytes.stream().map(String::valueOf)

--- a/obfuscator/src/main/resources/sources/native_jvm_output.cpp
+++ b/obfuscator/src/main/resources/sources/native_jvm_output.cpp
@@ -20,6 +20,7 @@ namespace native_jvm {
             return;
 
         char* string_pool = string_pool::get_pool();
+        string_pool::decrypt_pool();
 
 $register_code
 

--- a/obfuscator/src/main/resources/sources/string_pool.cpp
+++ b/obfuscator/src/main/resources/sources/string_pool.cpp
@@ -3,6 +3,16 @@
 namespace native_jvm::string_pool {
     static char pool[$size] = $value;
 
+    void decrypt_pool() {
+        for (size_t i = 0; i < $size; ++i) {
+            if (pool[i] != 0) {
+                unsigned char key = (i * 0x5A + 0xAC) & 0xFF;
+                unsigned char val = static_cast<unsigned char>(pool[i]) - 0x33;
+                pool[i] = static_cast<char>(val ^ key);
+            }
+        }
+    }
+
     char *get_pool() {
         return pool;
     }

--- a/obfuscator/src/main/resources/sources/string_pool.hpp
+++ b/obfuscator/src/main/resources/sources/string_pool.hpp
@@ -3,6 +3,7 @@
 #define STRING_POOL_HPP_GUARD
 
 namespace native_jvm::string_pool {
+    void decrypt_pool();
     char *get_pool();
 }
 

--- a/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
@@ -16,7 +16,17 @@ public class StringPoolTest {
                 "#include \"string_pool.hpp\"\n" +
                         "\n" +
                         "namespace native_jvm::string_pool {\n" +
-                        "    static char pool[5LL] = { 116, 101, 115, 116, 0 };\n" +
+                        "    static char pool[5LL] = { 11, 150, 70, 1, 0 };\n" +
+                        "\n" +
+                        "    void decrypt_pool() {\n" +
+                        "        for (size_t i = 0; i < 5LL; ++i) {\n" +
+                        "            if (pool[i] != 0) {\n" +
+                        "                unsigned char key = (i * 0x5A + 0xAC) & 0xFF;\n" +
+                        "                unsigned char val = static_cast<unsigned char>(pool[i]) - 0x33;\n" +
+                        "                pool[i] = static_cast<char>(val ^ key);\n" +
+                        "            }\n" +
+                        "        }\n" +
+                        "    }\n" +
                         "\n" +
                         "    char *get_pool() {\n" +
                         "        return pool;\n" +
@@ -29,7 +39,17 @@ public class StringPoolTest {
                 "#include \"string_pool.hpp\"\n" +
                         "\n" +
                         "namespace native_jvm::string_pool {\n" +
-                        "    static char pool[11LL] = { 116, 101, 115, 116, 0, 111, 116, 104, 101, 114, 0 };\n" +
+                        "    static char pool[11LL] = { 11, 150, 70, 1, 0, 52, 239, 125, 76, 215, 0 };\n" +
+                        "\n" +
+                        "    void decrypt_pool() {\n" +
+                        "        for (size_t i = 0; i < 11LL; ++i) {\n" +
+                        "            if (pool[i] != 0) {\n" +
+                        "                unsigned char key = (i * 0x5A + 0xAC) & 0xFF;\n" +
+                        "                unsigned char val = static_cast<unsigned char>(pool[i]) - 0x33;\n" +
+                        "                pool[i] = static_cast<char>(val ^ key);\n" +
+                        "            }\n" +
+                        "        }\n" +
+                        "    }\n" +
                         "\n" +
                         "    char *get_pool() {\n" +
                         "        return pool;\n" +


### PR DESCRIPTION
## Summary
- use index-based XOR and offset to encrypt string pool bytes
- decrypt pool at runtime with matching algorithm
- adjust tests for new encrypted values

## Testing
- `./gradlew test` (fails: 12 tests completed, 9 failed)


------
https://chatgpt.com/codex/tasks/task_e_68c2a914a99483329a04e8815bc0f981