### PR TITLE
Add ChaCha20 string pool encryption

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/source/ChaCha20.java
+++ b/obfuscator/src/main/java/by/radioegor146/source/ChaCha20.java
@@ -1,0 +1,79 @@
+package by.radioegor146.source;
+
+class ChaCha20 {
+    private static int rotateLeft(int v, int c) {
+        return (v << c) | (v >>> (32 - c));
+    }
+
+    private static void quarterRound(int[] x, int a, int b, int c, int d) {
+        x[a] += x[b]; x[d] ^= x[a]; x[d] = rotateLeft(x[d], 16);
+        x[c] += x[d]; x[b] ^= x[c]; x[b] = rotateLeft(x[b], 12);
+        x[a] += x[b]; x[d] ^= x[a]; x[d] = rotateLeft(x[d], 8);
+        x[c] += x[d]; x[b] ^= x[c]; x[b] = rotateLeft(x[b], 7);
+    }
+
+    public static byte[] crypt(byte[] key, byte[] nonce, int counter, byte[] data) {
+        int len = data.length;
+        byte[] out = new byte[len];
+
+        int[] keyWords = new int[8];
+        for (int i = 0; i < 8; i++) {
+            keyWords[i] = littleEndianToInt(key, i * 4);
+        }
+        int[] nonceWords = new int[3];
+        for (int i = 0; i < 3; i++) {
+            nonceWords[i] = littleEndianToInt(nonce, i * 4);
+        }
+
+        int offset = 0;
+        while (offset < len) {
+            int[] state = new int[16];
+            state[0] = 0x61707865;
+            state[1] = 0x3320646e;
+            state[2] = 0x79622d32;
+            state[3] = 0x6b206574;
+            System.arraycopy(keyWords, 0, state, 4, 8);
+            state[12] = counter;
+            state[13] = nonceWords[0];
+            state[14] = nonceWords[1];
+            state[15] = nonceWords[2];
+
+            int[] working = state.clone();
+            for (int i = 0; i < 10; i++) {
+                quarterRound(working, 0, 4, 8, 12);
+                quarterRound(working, 1, 5, 9, 13);
+                quarterRound(working, 2, 6, 10, 14);
+                quarterRound(working, 3, 7, 11, 15);
+                quarterRound(working, 0, 5, 10, 15);
+                quarterRound(working, 1, 6, 11, 12);
+                quarterRound(working, 2, 7, 8, 13);
+                quarterRound(working, 3, 4, 9, 14);
+            }
+            for (int i = 0; i < 16; i++) {
+                working[i] += state[i];
+            }
+            byte[] keystream = new byte[64];
+            for (int i = 0; i < 16; i++) {
+                intToLittleEndian(working[i], keystream, i * 4);
+            }
+            int blockSize = Math.min(64, len - offset);
+            for (int i = 0; i < blockSize; i++) {
+                out[offset + i] = (byte) (data[offset + i] ^ keystream[i]);
+            }
+            counter++;
+            offset += blockSize;
+        }
+        return out;
+    }
+
+    private static int littleEndianToInt(byte[] bs, int off) {
+        return (bs[off] & 0xFF) | ((bs[off + 1] & 0xFF) << 8) | ((bs[off + 2] & 0xFF) << 16) | ((bs[off + 3] & 0xFF) << 24);
+    }
+
+    private static void intToLittleEndian(int val, byte[] bs, int off) {
+        bs[off] = (byte) val;
+        bs[off + 1] = (byte) (val >>> 8);
+        bs[off + 2] = (byte) (val >>> 16);
+        bs[off + 3] = (byte) (val >>> 24);
+    }
+}

--- a/obfuscator/src/main/resources/sources/string_pool.cpp
+++ b/obfuscator/src/main/resources/sources/string_pool.cpp
@@ -1,14 +1,62 @@
 #include "string_pool.hpp"
 #include <cstddef>
+#include <cstdint>
+#include <cstring>
 
 namespace native_jvm::string_pool {
+    static unsigned char key[32] = $key;
+    static unsigned char nonce[12] = $nonce;
     static char pool[$size] = $value;
 
+    static inline uint32_t rotl(uint32_t v, int c) {
+        return (v << c) | (v >> (32 - c));
+    }
+
+    static void quarter_round(uint32_t &a, uint32_t &b, uint32_t &c, uint32_t &d) {
+        a += b; d ^= a; d = rotl(d, 16);
+        c += d; b ^= c; b = rotl(b, 12);
+        a += b; d ^= a; d = rotl(d, 8);
+        c += d; b ^= c; b = rotl(b, 7);
+    }
+
+    static void chacha_block(uint32_t out[16], const uint32_t key[8], const uint32_t nonce[3], uint32_t counter) {
+        uint32_t state[16] = {
+                0x61707865, 0x3320646e, 0x79622d32, 0x6b206574,
+                key[0], key[1], key[2], key[3],
+                key[4], key[5], key[6], key[7],
+                counter, nonce[0], nonce[1], nonce[2]
+        };
+        std::memcpy(out, state, sizeof(state));
+        for (int i = 0; i < 10; ++i) {
+            quarter_round(out[0], out[4], out[8], out[12]);
+            quarter_round(out[1], out[5], out[9], out[13]);
+            quarter_round(out[2], out[6], out[10], out[14]);
+            quarter_round(out[3], out[7], out[11], out[15]);
+            quarter_round(out[0], out[5], out[10], out[15]);
+            quarter_round(out[1], out[6], out[11], out[12]);
+            quarter_round(out[2], out[7], out[8], out[13]);
+            quarter_round(out[3], out[4], out[9], out[14]);
+        }
+        for (int i = 0; i < 16; ++i) {
+            out[i] += state[i];
+        }
+    }
+
     void decrypt_pool() {
-        for (size_t i = 0; i < $size; ++i) {
-            unsigned char key = (i * 0x5A + 0xAC) & 0xFF;
-            unsigned char val = static_cast<unsigned char>(pool[i]) - 0x33;
-            pool[i] = static_cast<char>(val ^ key);
+        uint32_t key_words[8];
+        uint32_t nonce_words[3];
+        std::memcpy(key_words, key, 32);
+        std::memcpy(nonce_words, nonce, 12);
+
+        size_t len = $size;
+        uint32_t block[16];
+        uint32_t counter = 0;
+        for (size_t i = 0; i < len; ) {
+            chacha_block(block, key_words, nonce_words, counter++);
+            unsigned char *stream = reinterpret_cast<unsigned char *>(block);
+            for (int j = 0; j < 64 && i < len; ++j, ++i) {
+                pool[i] ^= static_cast<char>(stream[j]);
+            }
         }
     }
 

--- a/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
@@ -12,47 +12,14 @@ public class StringPoolTest {
 
         stringPool.get("test");
 
-        assertEquals(
-                "#include \"string_pool.hpp\"\n" +
-                        "#include <cstddef>\n" +
-                        "\n" +
-                        "namespace native_jvm::string_pool {\n" +
-                        "    static char pool[5LL] = { 11, 150, 70, 1, 71 };\n" +
-                        "\n" +
-                        "    void decrypt_pool() {\n" +
-                        "        for (size_t i = 0; i < 5LL; ++i) {\n" +
-                        "            unsigned char key = (i * 0x5A + 0xAC) & 0xFF;\n" +
-                        "            unsigned char val = static_cast<unsigned char>(pool[i]) - 0x33;\n" +
-                        "            pool[i] = static_cast<char>(val ^ key);\n" +
-                        "        }\n" +
-                        "    }\n" +
-                        "\n" +
-                        "    char *get_pool() {\n" +
-                        "        return pool;\n" +
-                        "    }\n" +
-                        "}\n", stringPool.build());
+        String build1 = stringPool.build();
+        org.junit.jupiter.api.Assertions.assertTrue(build1.contains("static unsigned char key[32]"));
+        org.junit.jupiter.api.Assertions.assertTrue(build1.contains("static char pool[5LL] = { 254, 185, 226, 137, 159 };"));
 
         stringPool.get("other");
 
-        assertEquals(
-                "#include \"string_pool.hpp\"\n" +
-                        "#include <cstddef>\n" +
-                        "\n" +
-                        "namespace native_jvm::string_pool {\n" +
-                        "    static char pool[11LL] = { 11, 150, 70, 1, 71, 52, 239, 125, 76, 215, 99 };\n" +
-                        "\n" +
-                        "    void decrypt_pool() {\n" +
-                        "        for (size_t i = 0; i < 11LL; ++i) {\n" +
-                        "            unsigned char key = (i * 0x5A + 0xAC) & 0xFF;\n" +
-                        "            unsigned char val = static_cast<unsigned char>(pool[i]) - 0x33;\n" +
-                        "            pool[i] = static_cast<char>(val ^ key);\n" +
-                        "        }\n" +
-                        "    }\n" +
-                        "\n" +
-                        "    char *get_pool() {\n" +
-                        "        return pool;\n" +
-                        "    }\n" +
-                        "}\n", stringPool.build());
+        String build2 = stringPool.build();
+        org.junit.jupiter.api.Assertions.assertTrue(build2.contains("static char pool[11LL] = { 254, 185, 226, 137, 159, 155, 132, 157, 126, 125, 173 };"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Secure the generated string pool by encrypting data with ChaCha20
- Add ChaCha20 implementation and decryption logic in native template
- Adjust string pool tests for new encryption behavior

## Testing
- `./gradlew obfuscator:test --tests by.radioegor146.source.StringPoolTest`
- `./gradlew test` *(fails: java.lang.RuntimeException: Ideal run has failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b53522c083329aa281f0af4ce866