### PR TITLE
feat: on-demand string decryption and VM state expansion

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/NativeObfuscator.java
+++ b/obfuscator/src/main/java/by/radioegor146/NativeObfuscator.java
@@ -321,7 +321,7 @@ public class NativeObfuscator {
                     cMakeBuilder.addClassFile("output/" + hiddenClassFileName + ".cpp");
 
                     mainSourceBuilder.addHeader(hiddenClassFileName + ".hpp");
-                    mainSourceBuilder.registerDefine(stringPool.get(hiddenClass.name), hiddenClassFileName);
+                    mainSourceBuilder.registerDefine("string_pool::decrypt_string(" + stringPool.get(hiddenClass.name) + ")", hiddenClassFileName);
 
                     ClassWriter classWriter = new SafeClassWriter(metadataReader, Opcodes.ASM7 | ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
                     hiddenClass.accept(classWriter);

--- a/obfuscator/src/main/java/by/radioegor146/Snippets.java
+++ b/obfuscator/src/main/java/by/radioegor146/Snippets.java
@@ -58,7 +58,7 @@ public class Snippets {
             throw new RuntimeException(key + " - token value can't be null");
         });
 
-        result.entrySet().forEach(entry -> entry.setValue(stringPool.get(entry.getValue())));
+        result.entrySet().forEach(entry -> entry.setValue("string_pool::decrypt_string(" + stringPool.get(entry.getValue()) + ")"));
         tokens.forEach((k, v) -> result.putIfAbsent("$" + k, v));
 
         return Util.dynamicRawFormat(value, result);

--- a/obfuscator/src/main/java/by/radioegor146/source/StringPool.java
+++ b/obfuscator/src/main/java/by/radioegor146/source/StringPool.java
@@ -33,7 +33,9 @@ public class StringPool {
             pool.put(value, length);
             length += getModifiedUtf8Bytes(value).length + 1;
         }
-        return String.format("((char *)(string_pool + %dLL))", pool.get(value));
+        // Return the offset inside the encrypted pool. The caller is responsible
+        // for invoking string_pool::decrypt_string with this offset.
+        return String.format("%dLL", pool.get(value));
     }
 
     private static byte[] getModifiedUtf8Bytes(String str) {

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -27,12 +27,15 @@ struct Instruction {
     int64_t operand; // encrypted operand
 };
 
-// Helper that produces an encoded instruction using the global key.
-Instruction encode(OpCode op, int64_t operand, uint64_t key);
+// Helper that produces an encoded instruction using the same state
+// evolution as the runtime interpreter. The seed must match the value
+// passed to execute().
+Instruction encode(OpCode op, int64_t operand, uint64_t seed);
 
-// Executes a program encoded as an array of Instructions.  The
-// interpreter uses a stack based execution model and performs dynamic
-// decoding of every instruction.
+// Executes a program encoded as an array of Instructions.  The interpreter
+// uses a stack based execution model with two evolving internal state
+// registers.  Every instruction is decoded dynamically which complicates
+// static analysis of the resulting native code.
 void execute(const Instruction* code, size_t length, uint64_t seed = 0);
 
 } // namespace native_jvm::vm

--- a/obfuscator/src/main/resources/sources/native_jvm_output.cpp
+++ b/obfuscator/src/main/resources/sources/native_jvm_output.cpp
@@ -19,9 +19,6 @@ namespace native_jvm {
         if (env->ExceptionCheck())
             return;
 
-        char* string_pool = string_pool::get_pool();
-        string_pool::decrypt_pool();
-
 $register_code
 
         if (env->ExceptionCheck())

--- a/obfuscator/src/main/resources/sources/string_pool.hpp
+++ b/obfuscator/src/main/resources/sources/string_pool.hpp
@@ -2,9 +2,12 @@
 
 #define STRING_POOL_HPP_GUARD
 
+#include <cstddef>
+
 namespace native_jvm::string_pool {
-    void decrypt_pool();
-    char *get_pool();
+    // Decrypts a single string at the given offset and returns a pointer to
+    // the decrypted data. Only the requested string is decrypted in-place.
+    char *decrypt_string(std::size_t offset);
 }
 
 #endif

--- a/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
@@ -25,10 +25,10 @@ public class StringPoolTest {
     @Test
     public void testGet() {
         StringPool stringPool = new StringPool();
-        assertEquals("((char *)(string_pool + 0LL))", stringPool.get("test"));
-        assertEquals("((char *)(string_pool + 0LL))", stringPool.get("test"));
-        assertEquals("((char *)(string_pool + 5LL))", stringPool.get("\u0080\u0050"));
-        assertEquals("((char *)(string_pool + 9LL))", stringPool.get("\u0800"));
-        assertEquals("((char *)(string_pool + 13LL))", stringPool.get("\u0080"));
+        assertEquals("0LL", stringPool.get("test"));
+        assertEquals("0LL", stringPool.get("test"));
+        assertEquals("5LL", stringPool.get("\u0080\u0050"));
+        assertEquals("9LL", stringPool.get("\u0800"));
+        assertEquals("13LL", stringPool.get("\u0080"));
     }
 }


### PR DESCRIPTION
## Summary
- Decrypt strings individually at runtime instead of decoding the entire pool up front
- Adjust code generation to fetch and decrypt strings lazily using offsets
- Expand the micro VM with an additional evolving state register and matching encoder

## Testing
- `./gradlew test` *(fails: There were failing tests. See the report at: file:///workspace/native-obfuscator/obfuscator/build/reports/tests/test/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c78c09488332bf34931f5c5ebc42