### PR TITLE
Fix JNI string handling and add VM-based arithmetic

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
@@ -97,7 +97,7 @@ public class MethodProcessor {
 
     public static String getClassGetter(MethodContext context, String desc) {
         if (desc.startsWith("[")) {
-            return "env->FindClass(" + context.getStringPool().get(desc) + ")";
+            return "env->FindClass(string_pool::decrypt_string(" + context.getStringPool().get(desc) + "))";
         }
         if (desc.endsWith(";")) {
             desc = desc.substring(1, desc.length() - 1);
@@ -135,7 +135,7 @@ public class MethodProcessor {
             context.nativeMethod = context.proxyMethod.getMethodNode();
             context.nativeMethod.access |= Opcodes.ACC_NATIVE;
         } else {
-            context.nativeMethods.append(String.format("            { %s, %s, (void *)&%s },\n",
+        context.nativeMethods.append(String.format("            { string_pool::decrypt_string(%s), string_pool::decrypt_string(%s), (void *)&%s },\n",
                     obfuscator.getStringPool().get(context.method.name),
                     obfuscator.getStringPool().get(method.desc), methodName));
         }
@@ -168,8 +168,9 @@ public class MethodProcessor {
         output.append("    jobject classloader = utils::get_classloader_from_class(env, clazz);\n");
         output.append("    if (env->ExceptionCheck()) { ").append(String.format("return (%s) 0;",
                 CPP_TYPES[context.ret.getSort()])).append(" }\n");
-        output.append("    if (classloader == nullptr) { env->FatalError(").append(context.getStringPool()
-                .get("classloader == null")).append(String.format("); return (%s) 0; }\n", CPP_TYPES[context.ret.getSort()]));
+        output.append("    if (classloader == nullptr) { env->FatalError(string_pool::decrypt_string(")
+                .append(context.getStringPool().get("classloader == null"))
+                .append(String.format(")); return (%s) 0; }\n", CPP_TYPES[context.ret.getSort()]));
         output.append("\n");
         if (!isStatic) {
             output.append("    env->DeleteLocalRef(clazz);\n");

--- a/obfuscator/src/main/java/by/radioegor146/instructions/FieldHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/FieldHandler.java
@@ -36,7 +36,7 @@ public class FieldHandler extends GenericInstructionHandler<FieldInsnNode> {
         int fieldId = context.getCachedFields().getId(info);
         props.put("fieldid", context.getCachedFields().getPointer(info));
 
-        context.output.append(String.format("if (!cfields[%d]) { cfields[%d] = env->Get%sFieldID(%s, %s, %s); %s  } ",
+        context.output.append(String.format("if (!cfields[%d]) { cfields[%d] = env->Get%sFieldID(%s, string_pool::decrypt_string(%s), string_pool::decrypt_string(%s)); %s  } ",
                 fieldId,
                 fieldId,
                 isStatic ? "Static" : "",

--- a/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
@@ -198,7 +198,7 @@ public class MethodHandler extends GenericInstructionHandler<MethodInsnNode> {
         props.put("methodid", context.getCachedMethods().getPointer(methodInfo));
 
         context.output.append(
-                String.format("if (!cmethods[%d]) { cmethods[%d] = env->Get%sMethodID(%s, %s, %s); %s  } ",
+                String.format("if (!cmethods[%d]) { cmethods[%d] = env->Get%sMethodID(%s, string_pool::decrypt_string(%s), string_pool::decrypt_string(%s)); %s  } ",
                         methodId,
                         methodId,
                         isStatic ? "Static" : "",

--- a/obfuscator/src/main/resources/sources/cppsnippets.properties
+++ b/obfuscator/src/main/resources/sources/cppsnippets.properties
@@ -117,23 +117,23 @@ DUP2=cstack$stackindex0 = cstack$stackindexm2; cstack$stackindex1 = cstack$stack
 DUP2_X1=cstack$stackindex0 = cstack$stackindexm2; cstack$stackindex1 = cstack$stackindexm1; cstack$stackindexm1 = cstack$stackindexm3; cstack$stackindexm2 = cstack$stackindex1; cstack$stackindexm3 = cstack$stackindex0;
 DUP2_X2=cstack$stackindex0 = cstack$stackindexm2; cstack$stackindex1 = cstack$stackindexm1; cstack$stackindexm1 = cstack$stackindexm3; cstack$stackindexm2 = cstack$stackindexm4; cstack$stackindexm3 = cstack$stackindex1; cstack$stackindexm4 = cstack$stackindex0;
 SWAP=std::swap(cstack$stackindexm1, cstack$stackindexm2);
-IADD=cstack$stackindexm2.i = cstack$stackindexm2.i + cstack$stackindexm1.i;
-LADD=cstack$stackindexm4.j = cstack$stackindexm4.j + cstack$stackindexm2.j;
+IADD=cstack$stackindexm2.i = (jint) native_jvm::vm::binop(native_jvm::vm::OP_ADD, cstack$stackindexm2.i, cstack$stackindexm1.i);
+LADD=cstack$stackindexm4.j = native_jvm::vm::binop(native_jvm::vm::OP_ADD, cstack$stackindexm4.j, cstack$stackindexm2.j);
 FADD=cstack$stackindexm2.f = cstack$stackindexm2.f + cstack$stackindexm1.f;
 DADD=cstack$stackindexm4.d = cstack$stackindexm4.d + cstack$stackindexm2.d;
-ISUB=cstack$stackindexm2.i = cstack$stackindexm2.i - cstack$stackindexm1.i;
-LSUB=cstack$stackindexm4.j = cstack$stackindexm4.j - cstack$stackindexm2.j;
+ISUB=cstack$stackindexm2.i = (jint) native_jvm::vm::binop(native_jvm::vm::OP_SUB, cstack$stackindexm2.i, cstack$stackindexm1.i);
+LSUB=cstack$stackindexm4.j = native_jvm::vm::binop(native_jvm::vm::OP_SUB, cstack$stackindexm4.j, cstack$stackindexm2.j);
 FSUB=cstack$stackindexm2.f = cstack$stackindexm2.f - cstack$stackindexm1.f;
 DSUB=cstack$stackindexm4.d = cstack$stackindexm4.d - cstack$stackindexm2.d;
-IMUL=cstack$stackindexm2.i = cstack$stackindexm2.i * cstack$stackindexm1.i;
-LMUL=cstack$stackindexm4.j = cstack$stackindexm4.j * cstack$stackindexm2.j;
+IMUL=cstack$stackindexm2.i = (jint) native_jvm::vm::binop(native_jvm::vm::OP_MUL, cstack$stackindexm2.i, cstack$stackindexm1.i);
+LMUL=cstack$stackindexm4.j = native_jvm::vm::binop(native_jvm::vm::OP_MUL, cstack$stackindexm4.j, cstack$stackindexm2.j);
 FMUL=cstack$stackindexm2.f = cstack$stackindexm2.f * cstack$stackindexm1.f;
 DMUL=cstack$stackindexm4.d = cstack$stackindexm4.d * cstack$stackindexm2.d;
-IDIV=if (cstack$stackindexm1.i == -1 && cstack$stackindexm2.i == ((jint) 2147483648U)) { } else { if (cstack$stackindexm1.i == 0) { utils::throw_re(env, #AE, #ERROR_DESC, $line); $trycatchhandler } else { cstack$stackindexm2.i = cstack$stackindexm2.i / cstack$stackindexm1.i; } }
+IDIV=if (cstack$stackindexm1.i == -1 && cstack$stackindexm2.i == ((jint) 2147483648U)) { } else { if (cstack$stackindexm1.i == 0) { utils::throw_re(env, #AE, #ERROR_DESC, $line); $trycatchhandler } else { cstack$stackindexm2.i = (jint) native_jvm::vm::binop(native_jvm::vm::OP_DIV, cstack$stackindexm2.i, cstack$stackindexm1.i); } }
 IDIV_S_VARS=#AE,#ERROR_DESC
 IDIV_S_CONST_AE=java/lang/ArithmeticException
 IDIV_S_CONST_ERROR_DESC=IDIV / by 0
-LDIV=if (cstack$stackindexm2.j == -1 && cstack$stackindexm4.j == ((jlong) 9223372036854775808ULL)) { } else if (cstack$stackindexm2.j == 0) { utils::throw_re(env, #AE, #ERROR_DESC, $line); $trycatchhandler } else { cstack$stackindexm4.j = cstack$stackindexm4.j / cstack$stackindexm2.j; }
+LDIV=if (cstack$stackindexm2.j == -1 && cstack$stackindexm4.j == ((jlong) 9223372036854775808ULL)) { } else if (cstack$stackindexm2.j == 0) { utils::throw_re(env, #AE, #ERROR_DESC, $line); $trycatchhandler } else { cstack$stackindexm4.j = native_jvm::vm::binop(native_jvm::vm::OP_DIV, cstack$stackindexm4.j, cstack$stackindexm2.j); }
 LDIV_S_VARS=#AE,#ERROR_DESC
 LDIV_S_CONST_AE=java/lang/ArithmeticException
 LDIV_S_CONST_ERROR_DESC=LDIV / by 0

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -103,5 +103,15 @@ halt:
     return sp ? stack[sp - 1] : 0;
 }
 
+int64_t binop(OpCode op, int64_t a, int64_t b) {
+    uint64_t seed = (static_cast<uint64_t>(a) << 32) ^
+                    static_cast<uint64_t>(b) ^ KEY;
+    Instruction program[3];
+    program[0] = encode(OP_PUSH, a, seed);
+    program[1] = encode(OP_PUSH, b, seed);
+    program[2] = encode(op, 0, seed);
+    return execute(program, 3, seed);
+}
+
 } // namespace native_jvm::vm
 // NOLINTEND

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -39,6 +39,11 @@ Instruction encode(OpCode op, int64_t operand, uint64_t seed);
 // returned to allow the VM to participate in obfuscation routines.
 int64_t execute(const Instruction* code, size_t length, uint64_t seed = 0);
 
+// Convenience helper that builds a tiny program performing a binary
+// operation on two operands using the VM.  It returns the top of the VM
+// stack after execution which represents the result of the operation.
+int64_t binop(OpCode op, int64_t a, int64_t b);
+
 } // namespace native_jvm::vm
 
 // NOLINTEND

--- a/obfuscator/src/main/resources/sources/native_jvm.hpp
+++ b/obfuscator/src/main/resources/sources/native_jvm.hpp
@@ -12,6 +12,8 @@
 #include <mutex>
 #include <initializer_list>
 
+#include "micro_vm.hpp"
+
 #ifndef NATIVE_JVM_HPP_GUARD
 
 #define NATIVE_JVM_HPP_GUARD
@@ -79,6 +81,7 @@ namespace native_jvm::utils {
     jobject link_call_site(JNIEnv *env, jobject caller_obj, jobject bootstrap_method_obj,
             jobject name_obj, jobject type_obj, jobject static_arguments, jobject appendix_result);
 #endif
+
 
     jclass find_class_wo_static(JNIEnv *env, jobject classloader, jstring class_name);
 


### PR DESCRIPTION
## Summary
- decrypt string offsets before passing to JNI APIs
- route integer arithmetic through embedded VM for extra obfuscation
- expose VM helper and include it in native runtime

## Testing
- `./gradlew build` *(fails: There were failing tests. See the report at: file:///workspace/native-obfuscator/obfuscator/build/reports/tests/test/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ce41d1fc8332a394efcec420fe54