### PR TITLE
Fix loader class registration in native runtime

### DIFF
--- a/obfuscator/src/main/resources/sources/native_jvm_output.cpp
+++ b/obfuscator/src/main/resources/sources/native_jvm_output.cpp
@@ -29,7 +29,28 @@ $register_code
         JNINativeMethod loader_methods[] = {
             { (char *) method_name, (char *) method_desc, (void *)&register_for_class }
         };
-        env->RegisterNatives(env->FindClass("$native_dir/Loader"), loader_methods, 1);
+
+        jclass class_loader_class = env->FindClass("java/lang/ClassLoader");
+        if (env->ExceptionCheck())
+            return;
+        jmethodID get_system_loader = env->GetStaticMethodID(class_loader_class, "getSystemClassLoader", "()Ljava/lang/ClassLoader;");
+        if (env->ExceptionCheck())
+            return;
+        jobject system_loader = env->CallStaticObjectMethod(class_loader_class, get_system_loader);
+        if (env->ExceptionCheck())
+            return;
+        jmethodID load_class = env->GetMethodID(class_loader_class, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
+        if (env->ExceptionCheck())
+            return;
+        jstring loader_name = env->NewStringUTF("$native_dir.Loader");
+        jclass loader_class = (jclass) env->CallObjectMethod(system_loader, load_class, loader_name);
+        env->DeleteLocalRef(loader_name);
+        env->DeleteLocalRef(system_loader);
+        env->DeleteLocalRef(class_loader_class);
+        if (env->ExceptionCheck())
+            return;
+        env->RegisterNatives(loader_class, loader_methods, 1);
+        env->DeleteLocalRef(loader_class);
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid native crash when loading generated library by resolving Loader class through system class loader

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c2dba062d4833289871040061d78a3