### PR TITLE
Fix Windows JNI crash by using proper calling convention

### DIFF
--- a/obfuscator/src/main/resources/sources/native_jvm_output.cpp
+++ b/obfuscator/src/main/resources/sources/native_jvm_output.cpp
@@ -10,7 +10,7 @@ namespace native_jvm {
 
     reg_method reg_methods[$class_count];
 
-    void register_for_class(JNIEnv *env, jclass, jint id, jclass clazz) {
+    JNIEXPORT void JNICALL register_for_class(JNIEnv *env, jclass, jint id, jclass clazz) {
         reg_methods[id](env, clazz);
     }
 


### PR DESCRIPTION
## Summary
- Ensure generated `register_for_class` native method uses `JNIEXPORT`/`JNICALL`
- Prevents access violations when loading obfuscated JARs on Windows

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c2e3d74634833296cd8a422dba48bf