### PR TITLE
Fix JNI_OnLoad crash by clearing pending exceptions

### DIFF
--- a/obfuscator/src/main/resources/sources/native_jvm_output.cpp
+++ b/obfuscator/src/main/resources/sources/native_jvm_output.cpp
@@ -16,13 +16,17 @@ namespace native_jvm {
 
     void prepare_lib(JNIEnv *env) {
         utils::init_utils(env);
-        if (env->ExceptionCheck())
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
             return;
+        }
 
 $register_code
 
-        if (env->ExceptionCheck())
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
             return;
+        }
 
         char method_name[] = "registerNativesForClass";
         char method_desc[] = "(ILjava/lang/Class;)V";
@@ -31,26 +35,37 @@ $register_code
         };
 
         jclass class_loader_class = env->FindClass("java/lang/ClassLoader");
-        if (env->ExceptionCheck())
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
             return;
+        }
         jmethodID get_system_loader = env->GetStaticMethodID(class_loader_class, "getSystemClassLoader", "()Ljava/lang/ClassLoader;");
-        if (env->ExceptionCheck())
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
             return;
+        }
         jobject system_loader = env->CallStaticObjectMethod(class_loader_class, get_system_loader);
-        if (env->ExceptionCheck())
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
             return;
+        }
         jmethodID load_class = env->GetMethodID(class_loader_class, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
-        if (env->ExceptionCheck())
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
             return;
+        }
         jstring loader_name = env->NewStringUTF("$native_dir.Loader");
         jclass loader_class = (jclass) env->CallObjectMethod(system_loader, load_class, loader_name);
         env->DeleteLocalRef(loader_name);
         env->DeleteLocalRef(system_loader);
         env->DeleteLocalRef(class_loader_class);
-        if (env->ExceptionCheck() || loader_class == nullptr)
+        if (env->ExceptionCheck() || loader_class == nullptr) {
+            env->ExceptionClear();
             return;
+        }
         if (env->RegisterNatives(loader_class, loader_methods, 1) != JNI_OK || env->ExceptionCheck()) {
             env->DeleteLocalRef(loader_class);
+            env->ExceptionClear();
             return;
         }
         env->DeleteLocalRef(loader_class);
@@ -58,11 +73,15 @@ $register_code
 }
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
+    if (vm == nullptr)
+        return JNI_ERR;
     JNIEnv *env = nullptr;
     if (vm->GetEnv((void **)&env, JNI_VERSION_1_8) != JNI_OK || env == nullptr)
         return JNI_ERR;
     native_jvm::prepare_lib(env);
-    if (env->ExceptionCheck())
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
         return JNI_ERR;
+    }
     return JNI_VERSION_1_8;
 }


### PR DESCRIPTION
## Summary
- clear JNI exceptions during native library initialization
- ensure JNI_OnLoad validates the JavaVM and environment pointers

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c2e4efcaf88332a92b8ff1b04a4896