### PR TITLE
Fix string pool usage for JNI lookups

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
@@ -97,7 +97,7 @@ public class MethodProcessor {
 
     public static String getClassGetter(MethodContext context, String desc) {
         if (desc.startsWith("[")) {
-            return "env->FindClass(" + context.getStringPool().get(desc) + ")";
+            return "env->FindClass(string_pool::decrypt_string(" + context.getStringPool().get(desc) + "))";
         }
         if (desc.endsWith(";")) {
             desc = desc.substring(1, desc.length() - 1);
@@ -135,7 +135,7 @@ public class MethodProcessor {
             context.nativeMethod = context.proxyMethod.getMethodNode();
             context.nativeMethod.access |= Opcodes.ACC_NATIVE;
         } else {
-            context.nativeMethods.append(String.format("            { %s, %s, (void *)&%s },\n",
+            context.nativeMethods.append(String.format("            { string_pool::decrypt_string(%s), string_pool::decrypt_string(%s), (void *)&%s },\n",
                     obfuscator.getStringPool().get(context.method.name),
                     obfuscator.getStringPool().get(method.desc), methodName));
         }

--- a/obfuscator/src/main/java/by/radioegor146/instructions/FieldHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/FieldHandler.java
@@ -36,7 +36,7 @@ public class FieldHandler extends GenericInstructionHandler<FieldInsnNode> {
         int fieldId = context.getCachedFields().getId(info);
         props.put("fieldid", context.getCachedFields().getPointer(info));
 
-        context.output.append(String.format("if (!cfields[%d]) { cfields[%d] = env->Get%sFieldID(%s, %s, %s); %s  } ",
+        context.output.append(String.format("if (!cfields[%d]) { cfields[%d] = env->Get%sFieldID(%s, string_pool::decrypt_string(%s), string_pool::decrypt_string(%s)); %s  } ",
                 fieldId,
                 fieldId,
                 isStatic ? "Static" : "",

--- a/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
@@ -198,7 +198,7 @@ public class MethodHandler extends GenericInstructionHandler<MethodInsnNode> {
         props.put("methodid", context.getCachedMethods().getPointer(methodInfo));
 
         context.output.append(
-                String.format("if (!cmethods[%d]) { cmethods[%d] = env->Get%sMethodID(%s, %s, %s); %s  } ",
+                String.format("if (!cmethods[%d]) { cmethods[%d] = env->Get%sMethodID(%s, string_pool::decrypt_string(%s), string_pool::decrypt_string(%s)); %s  } ",
                         methodId,
                         methodId,
                         isStatic ? "Static" : "",


### PR DESCRIPTION
## Summary
- wrap JNI method/field lookups with `string_pool::decrypt_string`
- ensure array class lookups and native method registration decrypt pooled strings

## Testing
- `./gradlew test` *(fails: Exception in thread "main" java.lang.ClassNotFoundException: TestStringConcatFactory)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f25bbfcc83328759ee034980a221