### PR TITLE
Integrate micro VM for arithmetic operations

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/InsnHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/InsnHandler.java
@@ -8,7 +8,37 @@ import org.objectweb.asm.tree.InsnNode;
 public class InsnHandler extends GenericInstructionHandler<InsnNode> {
 
     @Override
-    protected void process(MethodContext context, InsnNode node) {}
+    protected void process(MethodContext context, InsnNode node) {
+        switch (node.getOpcode()) {
+            case Opcodes.IADD:
+                instructionName = null;
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(native_jvm::vm::OP_ADD, cstack%s.i, cstack%s.i);",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1")));
+                break;
+            case Opcodes.ISUB:
+                instructionName = null;
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(native_jvm::vm::OP_SUB, cstack%s.i, cstack%s.i);",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1")));
+                break;
+            case Opcodes.IMUL:
+                instructionName = null;
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(native_jvm::vm::OP_MUL, cstack%s.i, cstack%s.i);",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1")));
+                break;
+            case Opcodes.IDIV:
+                instructionName = null;
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(native_jvm::vm::OP_DIV, cstack%s.i, cstack%s.i);",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1")));
+                break;
+            default:
+                // handled via snippets
+                break;
+        }
+    }
 
     @Override
     public String insnToString(MethodContext context, InsnNode node) {

--- a/obfuscator/src/main/java/by/radioegor146/source/ClassSourceBuilder.java
+++ b/obfuscator/src/main/java/by/radioegor146/source/ClassSourceBuilder.java
@@ -40,6 +40,7 @@ public class ClassSourceBuilder implements AutoCloseable {
     public void addHeader(int strings, int classes, int methods, int fields) throws IOException {
         cppWriter.append("#include \"../native_jvm.hpp\"\n");
         cppWriter.append("#include \"../string_pool.hpp\"\n");
+        cppWriter.append("#include \"../micro_vm.hpp\"\n");
         cppWriter.append("#include \"").append(getHppFilename()).append("\"\n");
         cppWriter.append("\n");
         cppWriter.append("// ").append(Util.escapeCommentString(className)).append("\n");
@@ -65,6 +66,7 @@ public class ClassSourceBuilder implements AutoCloseable {
 
 
         hppWriter.append("#include \"../native_jvm.hpp\"\n");
+        hppWriter.append("#include \"../micro_vm.hpp\"\n");
         hppWriter.append("\n");
         hppWriter.append("#ifndef ").append(filename.concat("_hpp").toUpperCase()).append("_GUARD\n");
         hppWriter.append("\n");

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -32,8 +32,16 @@ Instruction encode(OpCode op, int64_t operand, uint64_t key);
 
 // Executes a program encoded as an array of Instructions.  The
 // interpreter uses a stack based execution model and performs dynamic
-// decoding of every instruction.
-void execute(const Instruction* code, size_t length, uint64_t seed = 0);
+// decoding of every instruction.  The return value is the top of the
+// stack after the program halts which allows host code to retrieve
+// computed values.
+int64_t execute(const Instruction* code, size_t length, uint64_t seed = 0);
+
+// Helper utility used by the obfuscator to perform simple arithmetic
+// through the VM.  It encodes a tiny program that evaluates
+//    result = lhs (op) rhs
+// for one of the arithmetic operations and returns the computed value.
+int64_t run_arith_vm(OpCode op, int64_t lhs, int64_t rhs, uint64_t seed = 0);
 
 } // namespace native_jvm::vm
 


### PR DESCRIPTION
## Summary
- expose micro VM execution result and add helper to encode simple arithmetic programs
- route integer arithmetic instructions through micro VM interpreter
- include micro_vm header in generated native class sources

## Testing
- `./gradlew test` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fa92b7808332adfaa42d669af17b