### PR TITLE
Randomize VM key and seed arithmetic calls

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/InsnHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/InsnHandler.java
@@ -4,40 +4,49 @@ import by.radioegor146.MethodContext;
 import by.radioegor146.Util;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.InsnNode;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class InsnHandler extends GenericInstructionHandler<InsnNode> {
 
     @Override
     protected void process(MethodContext context, InsnNode node) {
         switch (node.getOpcode()) {
-            case Opcodes.IADD:
+            case Opcodes.IADD: {
                 instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
                 context.output.append(String.format(
-                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_ADD, cstack%s.i, cstack%s.i);%s",
-                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"),
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_ADD, cstack%s.i, cstack%s.i, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"), seed,
                         props.get("trycatchhandler")));
                 break;
-            case Opcodes.ISUB:
+            }
+            case Opcodes.ISUB: {
                 instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
                 context.output.append(String.format(
-                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_SUB, cstack%s.i, cstack%s.i);%s",
-                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"),
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_SUB, cstack%s.i, cstack%s.i, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"), seed,
                         props.get("trycatchhandler")));
                 break;
-            case Opcodes.IMUL:
+            }
+            case Opcodes.IMUL: {
                 instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
                 context.output.append(String.format(
-                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_MUL, cstack%s.i, cstack%s.i);%s",
-                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"),
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_MUL, cstack%s.i, cstack%s.i, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"), seed,
                         props.get("trycatchhandler")));
                 break;
-            case Opcodes.IDIV:
+            }
+            case Opcodes.IDIV: {
                 instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
                 context.output.append(String.format(
-                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_DIV, cstack%s.i, cstack%s.i);%s",
-                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"),
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_DIV, cstack%s.i, cstack%s.i, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"), seed,
                         props.get("trycatchhandler")));
                 break;
+            }
             default:
                 // handled via snippets
                 break;

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -1,10 +1,17 @@
 #include "micro_vm.hpp"
 #include <iostream>
+#include <random>
 
 // NOLINTBEGIN - obfuscated control flow by design
 namespace native_jvm::vm {
 
-static constexpr uint64_t KEY = 0x5F3759DFB3E8A1C5ULL; // mixed 32/64-bit key
+static uint64_t KEY = 0;
+
+void init_key(uint64_t seed) {
+    std::random_device rd;
+    std::mt19937_64 gen(rd() ^ seed);
+    KEY = gen();
+}
 
 Instruction encode(OpCode op, int64_t operand, uint64_t key) {
     return Instruction{
@@ -91,6 +98,8 @@ halt:
 }
 
 int64_t run_arith_vm(JNIEnv* env, OpCode op, int64_t lhs, int64_t rhs, uint64_t seed) {
+    init_key(seed);
+
     Instruction program[4];
     uint64_t state = KEY ^ seed;
 

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -31,18 +31,22 @@ struct Instruction {
 // Helper that produces an encoded instruction using the global key.
 Instruction encode(OpCode op, int64_t operand, uint64_t key);
 
+// Initializes the global KEY used for encoding/decoding instructions.
+// Must be called before executing any VM code.
+void init_key(uint64_t seed);
+
 // Executes a program encoded as an array of Instructions.  The
 // interpreter uses a stack based execution model and performs dynamic
 // decoding of every instruction.  The return value is the top of the
 // stack after the program halts which allows host code to retrieve
 // computed values.
-int64_t execute(JNIEnv* env, const Instruction* code, size_t length, uint64_t seed = 0);
+int64_t execute(JNIEnv* env, const Instruction* code, size_t length, uint64_t seed);
 
 // Helper utility used by the obfuscator to perform simple arithmetic
 // through the VM.  It encodes a tiny program that evaluates
 //    result = lhs (op) rhs
 // for one of the arithmetic operations and returns the computed value.
-int64_t run_arith_vm(JNIEnv* env, OpCode op, int64_t lhs, int64_t rhs, uint64_t seed = 0);
+int64_t run_arith_vm(JNIEnv* env, OpCode op, int64_t lhs, int64_t rhs, uint64_t seed);
 
 } // namespace native_jvm::vm
 


### PR DESCRIPTION
## Summary
- Generate VM key at runtime via `init_key` using `std::random_device` and `std::mt19937_64`
- Require callers to pass a seed and initialize the key for `execute` and `run_arith_vm`
- Emit random seeds from `InsnHandler` when invoking the arithmetic VM

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c39716adb88332a76cdf7051ed8164