### PR TITLE
Add per-instruction nonce and per-method VM key

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
@@ -10,6 +10,7 @@ import org.objectweb.asm.tree.*;
 
 import java.lang.reflect.Field;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 public class MethodProcessor {
@@ -180,6 +181,9 @@ public class MethodProcessor {
                     CPP_TYPES[context.ret.getSort()])).append(" }\n");
         }
         output.append("    jobject lookup = nullptr;\n");
+
+        long vmKeySeed = ThreadLocalRandom.current().nextLong();
+        output.append(String.format("    native_jvm::vm::init_key(%dLL);\n", vmKeySeed));
 
         if (method.tryCatchBlocks != null) {
             for (TryCatchBlockNode tryCatch : method.tryCatchBlocks) {

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -31,10 +31,11 @@ enum OpCode : uint8_t {
 struct Instruction {
     uint8_t op;      // encrypted opcode
     int64_t operand; // encrypted operand
+    uint64_t nonce;  // per-instruction random nonce
 };
 
 // Helper that produces an encoded instruction using the global key.
-Instruction encode(OpCode op, int64_t operand, uint64_t key);
+Instruction encode(OpCode op, int64_t operand, uint64_t key, uint64_t nonce);
 
 // Initializes the global KEY used for encoding/decoding instructions.
 // Must be called before executing any VM code.


### PR DESCRIPTION
## Summary
- Track a 64-bit nonce per micro VM instruction for stronger opcode and operand obfuscation
- Decode instructions using both global KEY and per-instruction nonce
- Generate a new VM KEY for each method and drop `init_key` call from `run_arith_vm`

## Testing
- `./gradlew test` *(fails: Could not write XML test results)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d60dd92883329f35005fbef45767