### PR TITLE
Add micro VM translation layer for JVM bytecode

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -1,0 +1,128 @@
+package by.radioegor146.instructions;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+
+import java.util.*;
+
+/**
+ * Translates a limited subset of JVM bytecode instructions into the
+ * custom micro VM instruction set.  If an unsupported instruction is
+ * encountered the translator returns {@code null} to signal that the
+ * caller should fall back to the normal native generation path.
+ */
+public class VmTranslator {
+
+    /** Representation of a VM instruction. */
+    public static class Instruction {
+        public final int opcode;
+        public final int operand;
+
+        public Instruction(int opcode, int operand) {
+            this.opcode = opcode;
+            this.operand = operand;
+        }
+    }
+
+    /** Constants mirroring native_jvm::vm::OpCode. */
+    public static class VmOpcodes {
+        public static final int OP_PUSH = 0;
+        public static final int OP_ADD = 1;
+        public static final int OP_SUB = 2;
+        public static final int OP_MUL = 3;
+        public static final int OP_DIV = 4;
+        public static final int OP_PRINT = 5;
+        public static final int OP_HALT = 6;
+        public static final int OP_NOP = 7;
+        public static final int OP_JUNK1 = 8;
+        public static final int OP_JUNK2 = 9;
+        public static final int OP_SWAP = 10;
+        public static final int OP_DUP = 11;
+        public static final int OP_LOAD = 12;
+        public static final int OP_IF_ICMPEQ = 13;
+        public static final int OP_IF_ICMPNE = 14;
+        public static final int OP_GOTO = 15;
+    }
+
+    /**
+     * Attempts to translate the provided method.  On success an array of
+     * VM instructions is returned.  On failure {@code null} is returned
+     * so that the caller can provide a fallback implementation.
+     */
+    public Instruction[] translate(MethodNode method) {
+        Map<LabelNode, Integer> labelIds = new HashMap<>();
+        int index = 0;
+        for (AbstractInsnNode insn = method.instructions.getFirst(); insn != null; insn = insn.getNext()) {
+            if (insn instanceof LabelNode) {
+                labelIds.put((LabelNode) insn, index);
+            } else if (!(insn instanceof LineNumberNode) && !(insn instanceof FrameNode)) {
+                index++;
+            }
+        }
+
+        List<Instruction> result = new ArrayList<>();
+        for (AbstractInsnNode insn = method.instructions.getFirst(); insn != null; insn = insn.getNext()) {
+            int opcode = insn.getOpcode();
+            switch (opcode) {
+                case Opcodes.ILOAD:
+                    result.add(new Instruction(VmOpcodes.OP_LOAD, ((VarInsnNode) insn).var));
+                    break;
+                case 26: // ILOAD_0
+                case 27: // ILOAD_1
+                case 28: // ILOAD_2
+                case 29: // ILOAD_3
+                    result.add(new Instruction(VmOpcodes.OP_LOAD, opcode - 26));
+                    break;
+                case Opcodes.IADD:
+                    result.add(new Instruction(VmOpcodes.OP_ADD, 0));
+                    break;
+                case Opcodes.BIPUSH:
+                case Opcodes.SIPUSH:
+                    result.add(new Instruction(VmOpcodes.OP_PUSH, ((IntInsnNode) insn).operand));
+                    break;
+                case Opcodes.ICONST_M1:
+                case Opcodes.ICONST_0:
+                case Opcodes.ICONST_1:
+                case Opcodes.ICONST_2:
+                case Opcodes.ICONST_3:
+                case Opcodes.ICONST_4:
+                case Opcodes.ICONST_5:
+                    int val = opcode - Opcodes.ICONST_0;
+                    if (opcode == Opcodes.ICONST_M1) val = -1;
+                    result.add(new Instruction(VmOpcodes.OP_PUSH, val));
+                    break;
+                case Opcodes.GOTO:
+                    result.add(new Instruction(VmOpcodes.OP_GOTO, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IF_ICMPEQ:
+                    result.add(new Instruction(VmOpcodes.OP_IF_ICMPEQ, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IF_ICMPNE:
+                    result.add(new Instruction(VmOpcodes.OP_IF_ICMPNE, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IRETURN:
+                    result.add(new Instruction(VmOpcodes.OP_HALT, 0));
+                    break;
+                case -1: // labels/frames/lines
+                    break;
+                default:
+                    return null; // unsupported instruction
+            }
+        }
+        return result.toArray(new Instruction[0]);
+    }
+
+    /** Serializes VM instructions into a C++ initializer string. */
+    public static String serialize(Instruction[] code) {
+        StringBuilder sb = new StringBuilder();
+        sb.append('{');
+        for (int i = 0; i < code.length; i++) {
+            Instruction ins = code[i];
+            sb.append(String.format("{ %d, %d, 0ULL }", ins.opcode, (long) ins.operand));
+            if (i + 1 < code.length) sb.append(", ");
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+}
+

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -22,7 +22,11 @@ enum OpCode : uint8_t {
     OP_JUNK2 = 9,  // another harmless operation
     OP_SWAP  = 10, // swap two top stack values
     OP_DUP   = 11, // duplicate top stack value
-    OP_COUNT = 12  // helper constant with number of opcodes
+    OP_LOAD  = 12, // load local variable onto the stack
+    OP_IF_ICMPEQ = 13, // compare two ints and jump if equal
+    OP_IF_ICMPNE = 14, // compare two ints and jump if not equal
+    OP_GOTO = 15, // unconditional jump
+    OP_COUNT = 16  // helper constant with number of opcodes
 };
 
 // Every field of an instruction is lightly encrypted and decoded at
@@ -45,8 +49,15 @@ void init_key(uint64_t seed);
 // interpreter uses a stack based execution model and performs dynamic
 // decoding of every instruction.  The return value is the top of the
 // stack after the program halts which allows host code to retrieve
-// computed values.
-int64_t execute(JNIEnv* env, const Instruction* code, size_t length, uint64_t seed);
+// computed values. Locals should point to an array of initial local
+// variables for OP_LOAD instructions.
+int64_t execute(JNIEnv* env, const Instruction* code, size_t length,
+                const int64_t* locals, size_t locals_length, uint64_t seed);
+
+// Encodes a program in-place using the internal key so that it can be
+// executed by the VM.  The seed should be the same value passed to
+// execute.
+void encode_program(Instruction* code, size_t length, uint64_t seed);
 
 // Helper utility used by the obfuscator to perform simple arithmetic
 // through the VM.  It encodes a tiny program that evaluates

--- a/obfuscator/test_data/tests/java-obfuscator-test/JavaObfuscatorTest/Test.java
+++ b/obfuscator/test_data/tests/java-obfuscator-test/JavaObfuscatorTest/Test.java
@@ -1,2 +1,5 @@
 public class Test {
+    public static int vmAdd(int a, int b) {
+        return a + b;
+    }
 }


### PR DESCRIPTION
## Summary
- extend micro VM with load and branch opcodes and expose encode_program helper
- implement `VmTranslator` converting selected JVM bytecode to VM instructions
- integrate translator into `MethodProcessor` and serialize/execute VM programs
- add sample `vmAdd` method to exercise virtualization path

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c3dcbdf2c08332adca076be6544311