### PR TITLE
Handle empty VM translations and avoid zero-length locals

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
@@ -188,10 +188,10 @@ public class MethodProcessor {
 
         VmTranslator vmTranslator = new VmTranslator();
         VmTranslator.Instruction[] vmCode = vmTranslator.translate(method);
-        if (vmCode != null) {
+        if (vmCode != null && vmCode.length > 0) {
             output.append(String.format("    native_jvm::vm::Instruction __ngen_vm_code[] = %s;\n",
                     VmTranslator.serialize(vmCode)));
-            output.append(String.format("    jlong __ngen_vm_locals[%d] = {0};\n", method.maxLocals));
+            output.append(String.format("    jlong __ngen_vm_locals[%d] = {0};\n", Math.max(1, method.maxLocals)));
             for (int i = 0; i < argNames.size(); i++) {
                 output.append(String.format("    __ngen_vm_locals[%d] = (jlong)%s;\n", i, argNames.get(i)));
             }

--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -109,6 +109,9 @@ public class VmTranslator {
                     return null; // unsupported instruction
             }
         }
+        if (result.isEmpty()) {
+            return null;
+        }
         return result.toArray(new Instruction[0]);
     }
 

--- a/obfuscator/test_data/tests/clinit/EmptyClinit/Test.java
+++ b/obfuscator/test_data/tests/clinit/EmptyClinit/Test.java
@@ -1,0 +1,7 @@
+public class Test {
+    public static void main(String[] args) {
+        System.out.println("OK");
+    }
+    static {
+    }
+}


### PR DESCRIPTION
## Summary
- Skip VM execution when translation produces no instructions
- Ensure VM locals array is at least size one
- Return `null` for empty VM translations and add regression test for empty `<clinit>`

## Testing
- `./gradlew test` *(fails: stops at `IssueDivZero` test)*

------
https://chatgpt.com/codex/tasks/task_e_68c3dff899ec833292f2072f237b98d2