### PR TITLE
Ensure VM-processed methods run cleanup

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
@@ -202,6 +202,11 @@ public class MethodProcessor {
                     "    return (%s)native_jvm::vm::execute(env, __ngen_vm_code, %d, __ngen_vm_locals, %d, %dLL);\n",
                     CPP_TYPES[context.ret.getSort()], vmCode.length, method.maxLocals, vmKeySeed));
             output.append("}\n");
+
+            method.localVariables.clear();
+            method.tryCatchBlocks.clear();
+
+            specialMethodProcessor.postProcess(context);
             return;
         }
 


### PR DESCRIPTION
## Summary
- Clear local variables and try-catch blocks and run post-processing when emitting VM code

## Testing
- `./gradlew build`
- `javap -v -classpath test_tmp/out/test.jar Test`

------
https://chatgpt.com/codex/tasks/task_e_68c3ebcfef908332acbee45f76df23e8