### PR TITLE
Expand micro VM support for logic, comparisons and conversions

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
@@ -186,6 +186,7 @@ public class MethodProcessor {
         long vmKeySeed = ThreadLocalRandom.current().nextLong();
         output.append(String.format("    native_jvm::vm::init_key(%dLL);\n", vmKeySeed));
 
+        // Try to translate entire method into VM instructions first.
         VmTranslator vmTranslator = new VmTranslator();
         VmTranslator.Instruction[] vmCode = vmTranslator.translate(method);
         if (vmCode != null && vmCode.length > 0) {
@@ -209,6 +210,7 @@ public class MethodProcessor {
             specialMethodProcessor.postProcess(context);
             return;
         }
+        // Fallback path: generate native templates when VM translation is not possible.
 
         if (method.tryCatchBlocks != null) {
             for (TryCatchBlockNode tryCatch : method.tryCatchBlocks) {

--- a/obfuscator/src/main/java/by/radioegor146/instructions/InsnHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/InsnHandler.java
@@ -75,6 +75,100 @@ public class InsnHandler extends GenericInstructionHandler<InsnNode> {
                         props.get("trycatchhandler")));
                 break;
             }
+            case Opcodes.IAND: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_AND, cstack%s.i, cstack%s.i, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"), seed,
+                        props.get("trycatchhandler")));
+                break;
+            }
+            case Opcodes.IOR: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_OR, cstack%s.i, cstack%s.i, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"), seed,
+                        props.get("trycatchhandler")));
+                break;
+            }
+            case Opcodes.IXOR: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_XOR, cstack%s.i, cstack%s.i, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"), seed,
+                        props.get("trycatchhandler")));
+                break;
+            }
+            case Opcodes.ISHL: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_SHL, cstack%s.i, cstack%s.i, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"), seed,
+                        props.get("trycatchhandler")));
+                break;
+            }
+            case Opcodes.ISHR: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_SHR, cstack%s.i, cstack%s.i, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"), seed,
+                        props.get("trycatchhandler")));
+                break;
+            }
+            case Opcodes.IUSHR: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_USHR, cstack%s.i, cstack%s.i, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), props.get("stackindexm1"), seed,
+                        props.get("trycatchhandler")));
+                break;
+            }
+            case Opcodes.I2B: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_I2B, cstack%s.i, 0, %dLL);%s",
+                        props.get("stackindexm1"), props.get("stackindexm1"), seed, props.get("trycatchhandler")));
+                break;
+            }
+            case Opcodes.I2C: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_I2C, cstack%s.i, 0, %dLL);%s",
+                        props.get("stackindexm1"), props.get("stackindexm1"), seed, props.get("trycatchhandler")));
+                break;
+            }
+            case Opcodes.I2S: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_I2S, cstack%s.i, 0, %dLL);%s",
+                        props.get("stackindexm1"), props.get("stackindexm1"), seed, props.get("trycatchhandler")));
+                break;
+            }
+            case Opcodes.I2L: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.j = native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_I2L, cstack%s.i, 0, %dLL);%s",
+                        props.get("stackindexm1"), props.get("stackindexm1"), seed, props.get("trycatchhandler")));
+                break;
+            }
+            case Opcodes.L2I: {
+                instructionName = null;
+                long seed = ThreadLocalRandom.current().nextLong();
+                context.output.append(String.format(
+                        "cstack%s.i = (jint)native_jvm::vm::run_arith_vm(env, native_jvm::vm::OP_L2I, cstack%s.j, 0, %dLL);%s",
+                        props.get("stackindexm2"), props.get("stackindexm2"), seed, props.get("trycatchhandler")));
+                break;
+            }
             default:
                 // handled via snippets
                 break;

--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -43,6 +43,27 @@ public class VmTranslator {
         public static final int OP_IF_ICMPNE = 14;
         public static final int OP_GOTO = 15;
         public static final int OP_STORE = 16;
+        public static final int OP_AND = 17;
+        public static final int OP_OR = 18;
+        public static final int OP_XOR = 19;
+        public static final int OP_SHL = 20;
+        public static final int OP_SHR = 21;
+        public static final int OP_USHR = 22;
+        public static final int OP_IF_ICMPLT = 23;
+        public static final int OP_IF_ICMPLE = 24;
+        public static final int OP_IF_ICMPGT = 25;
+        public static final int OP_IF_ICMPGE = 26;
+        public static final int OP_IFEQ = 27;
+        public static final int OP_IFNE = 28;
+        public static final int OP_IFLT = 29;
+        public static final int OP_IFLE = 30;
+        public static final int OP_IFGT = 31;
+        public static final int OP_IFGE = 32;
+        public static final int OP_I2L = 33;
+        public static final int OP_L2I = 34;
+        public static final int OP_I2B = 35;
+        public static final int OP_I2C = 36;
+        public static final int OP_I2S = 37;
     }
 
     /**
@@ -86,6 +107,24 @@ public class VmTranslator {
                 case Opcodes.IDIV:
                     result.add(new Instruction(VmOpcodes.OP_DIV, 0));
                     break;
+                case Opcodes.IAND:
+                    result.add(new Instruction(VmOpcodes.OP_AND, 0));
+                    break;
+                case Opcodes.IOR:
+                    result.add(new Instruction(VmOpcodes.OP_OR, 0));
+                    break;
+                case Opcodes.IXOR:
+                    result.add(new Instruction(VmOpcodes.OP_XOR, 0));
+                    break;
+                case Opcodes.ISHL:
+                    result.add(new Instruction(VmOpcodes.OP_SHL, 0));
+                    break;
+                case Opcodes.ISHR:
+                    result.add(new Instruction(VmOpcodes.OP_SHR, 0));
+                    break;
+                case Opcodes.IUSHR:
+                    result.add(new Instruction(VmOpcodes.OP_USHR, 0));
+                    break;
                 case Opcodes.BIPUSH:
                 case Opcodes.SIPUSH:
                     result.add(new Instruction(VmOpcodes.OP_PUSH, ((IntInsnNode) insn).operand));
@@ -118,6 +157,51 @@ public class VmTranslator {
                     break;
                 case Opcodes.IF_ICMPNE:
                     result.add(new Instruction(VmOpcodes.OP_IF_ICMPNE, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IF_ICMPLT:
+                    result.add(new Instruction(VmOpcodes.OP_IF_ICMPLT, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IF_ICMPLE:
+                    result.add(new Instruction(VmOpcodes.OP_IF_ICMPLE, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IF_ICMPGT:
+                    result.add(new Instruction(VmOpcodes.OP_IF_ICMPGT, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IF_ICMPGE:
+                    result.add(new Instruction(VmOpcodes.OP_IF_ICMPGE, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IFEQ:
+                    result.add(new Instruction(VmOpcodes.OP_IFEQ, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IFNE:
+                    result.add(new Instruction(VmOpcodes.OP_IFNE, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IFLT:
+                    result.add(new Instruction(VmOpcodes.OP_IFLT, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IFLE:
+                    result.add(new Instruction(VmOpcodes.OP_IFLE, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IFGT:
+                    result.add(new Instruction(VmOpcodes.OP_IFGT, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.IFGE:
+                    result.add(new Instruction(VmOpcodes.OP_IFGE, labelIds.get(((JumpInsnNode) insn).label)));
+                    break;
+                case Opcodes.I2L:
+                    result.add(new Instruction(VmOpcodes.OP_I2L, 0));
+                    break;
+                case Opcodes.L2I:
+                    result.add(new Instruction(VmOpcodes.OP_L2I, 0));
+                    break;
+                case Opcodes.I2B:
+                    result.add(new Instruction(VmOpcodes.OP_I2B, 0));
+                    break;
+                case Opcodes.I2C:
+                    result.add(new Instruction(VmOpcodes.OP_I2C, 0));
+                    break;
+                case Opcodes.I2S:
+                    result.add(new Instruction(VmOpcodes.OP_I2S, 0));
                     break;
                 case Opcodes.IRETURN:
                     result.add(new Instruction(VmOpcodes.OP_HALT, 0));

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -83,6 +83,27 @@ dispatch:
         case OP_STORE: goto do_store;
         case OP_IF_ICMPEQ: goto do_if_icmpeq;
         case OP_IF_ICMPNE: goto do_if_icmpne;
+        case OP_AND:   goto do_and;
+        case OP_OR:    goto do_or;
+        case OP_XOR:   goto do_xor;
+        case OP_SHL:   goto do_shl;
+        case OP_SHR:   goto do_shr;
+        case OP_USHR:  goto do_ushr;
+        case OP_IF_ICMPLT: goto do_if_icmplt;
+        case OP_IF_ICMPLE: goto do_if_icmple;
+        case OP_IF_ICMPGT: goto do_if_icmpgt;
+        case OP_IF_ICMPGE: goto do_if_icmpge;
+        case OP_IFEQ:  goto do_ifeq;
+        case OP_IFNE:  goto do_ifne;
+        case OP_IFLT:  goto do_iflt;
+        case OP_IFLE:  goto do_ifle;
+        case OP_IFGT:  goto do_ifgt;
+        case OP_IFGE:  goto do_ifge;
+        case OP_I2L:   goto do_i2l;
+        case OP_L2I:   goto do_l2i;
+        case OP_I2B:   goto do_i2b;
+        case OP_I2C:   goto do_i2c;
+        case OP_I2S:   goto do_i2s;
         case OP_GOTO:  goto do_goto;
         default:       goto halt;
     }
@@ -154,6 +175,30 @@ do_store:
     }
     goto dispatch;
 
+do_and:
+    if (sp >= 2) { stack[sp - 2] &= stack[sp - 1]; --sp; }
+    goto dispatch;
+
+do_or:
+    if (sp >= 2) { stack[sp - 2] |= stack[sp - 1]; --sp; }
+    goto dispatch;
+
+do_xor:
+    if (sp >= 2) { stack[sp - 2] ^= stack[sp - 1]; --sp; }
+    goto dispatch;
+
+do_shl:
+    if (sp >= 2) { stack[sp - 2] <<= (int)(stack[sp - 1] & 0x1F); --sp; }
+    goto dispatch;
+
+do_shr:
+    if (sp >= 2) { stack[sp - 2] >>= (int)(stack[sp - 1] & 0x1F); --sp; }
+    goto dispatch;
+
+do_ushr:
+    if (sp >= 2) { stack[sp - 2] = (int64_t)((uint64_t)stack[sp - 2] >> (stack[sp - 1] & 0x1F)); --sp; }
+    goto dispatch;
+
 do_if_icmpeq:
     if (sp >= 2) {
         int64_t b = stack[sp - 1];
@@ -170,6 +215,110 @@ do_if_icmpne:
         sp -= 2;
         if (a != b) pc = static_cast<size_t>(tmp);
     }
+    goto dispatch;
+
+do_if_icmplt:
+    if (sp >= 2) {
+        int64_t b = stack[sp - 1];
+        int64_t a = stack[sp - 2];
+        sp -= 2;
+        if (a < b) pc = static_cast<size_t>(tmp);
+    }
+    goto dispatch;
+
+do_if_icmple:
+    if (sp >= 2) {
+        int64_t b = stack[sp - 1];
+        int64_t a = stack[sp - 2];
+        sp -= 2;
+        if (a <= b) pc = static_cast<size_t>(tmp);
+    }
+    goto dispatch;
+
+do_if_icmpgt:
+    if (sp >= 2) {
+        int64_t b = stack[sp - 1];
+        int64_t a = stack[sp - 2];
+        sp -= 2;
+        if (a > b) pc = static_cast<size_t>(tmp);
+    }
+    goto dispatch;
+
+do_if_icmpge:
+    if (sp >= 2) {
+        int64_t b = stack[sp - 1];
+        int64_t a = stack[sp - 2];
+        sp -= 2;
+        if (a >= b) pc = static_cast<size_t>(tmp);
+    }
+    goto dispatch;
+
+do_ifeq:
+    if (sp >= 1) {
+        int64_t a = stack[sp - 1];
+        --sp;
+        if (a == 0) pc = static_cast<size_t>(tmp);
+    }
+    goto dispatch;
+
+do_ifne:
+    if (sp >= 1) {
+        int64_t a = stack[sp - 1];
+        --sp;
+        if (a != 0) pc = static_cast<size_t>(tmp);
+    }
+    goto dispatch;
+
+do_iflt:
+    if (sp >= 1) {
+        int64_t a = stack[sp - 1];
+        --sp;
+        if (a < 0) pc = static_cast<size_t>(tmp);
+    }
+    goto dispatch;
+
+do_ifle:
+    if (sp >= 1) {
+        int64_t a = stack[sp - 1];
+        --sp;
+        if (a <= 0) pc = static_cast<size_t>(tmp);
+    }
+    goto dispatch;
+
+do_ifgt:
+    if (sp >= 1) {
+        int64_t a = stack[sp - 1];
+        --sp;
+        if (a > 0) pc = static_cast<size_t>(tmp);
+    }
+    goto dispatch;
+
+do_ifge:
+    if (sp >= 1) {
+        int64_t a = stack[sp - 1];
+        --sp;
+        if (a >= 0) pc = static_cast<size_t>(tmp);
+    }
+    goto dispatch;
+
+do_i2l:
+    if (sp >= 1) { stack[sp - 1] = static_cast<int64_t>(static_cast<int32_t>(stack[sp - 1])); }
+    goto dispatch;
+
+do_l2i:
+    if (sp >= 1) { stack[sp - 1] = static_cast<int32_t>(stack[sp - 1]); }
+    goto dispatch;
+
+do_i2b:
+    if (sp >= 1) { stack[sp - 1] = static_cast<int8_t>(stack[sp - 1]); }
+    goto dispatch;
+
+do_i2c:
+    if (sp >= 1) { stack[sp - 1] = static_cast<uint16_t>(stack[sp - 1]); }
+    goto dispatch;
+
+do_i2s:
+    if (sp >= 1) { stack[sp - 1] = static_cast<int16_t>(stack[sp - 1]); }
     goto dispatch;
 
 do_goto:
@@ -222,8 +371,18 @@ int64_t run_arith_vm(JNIEnv* env, OpCode op, int64_t lhs, int64_t rhs, uint64_t 
 
     emit(OP_PUSH, lhs);
     emit_junk();
-    emit(OP_PUSH, rhs);
-    emit_junk();
+    switch (op) {
+        case OP_I2L:
+        case OP_L2I:
+        case OP_I2B:
+        case OP_I2C:
+        case OP_I2S:
+            break; // unary operations, no second push
+        default:
+            emit(OP_PUSH, rhs);
+            emit_junk();
+            break;
+    }
     emit(op, 0);
     emit_junk();
     emit(OP_HALT, 0);

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -27,7 +27,31 @@ enum OpCode : uint8_t {
     OP_IF_ICMPNE = 14, // compare two ints and jump if not equal
     OP_GOTO = 15, // unconditional jump
     OP_STORE = 16, // store top of stack into local variable
-    OP_COUNT = 17  // helper constant with number of opcodes
+    // logical/bitwise operations
+    OP_AND   = 17,
+    OP_OR    = 18,
+    OP_XOR   = 19,
+    OP_SHL   = 20,
+    OP_SHR   = 21,
+    OP_USHR  = 22,
+    // additional comparisons
+    OP_IF_ICMPLT = 23,
+    OP_IF_ICMPLE = 24,
+    OP_IF_ICMPGT = 25,
+    OP_IF_ICMPGE = 26,
+    OP_IFEQ = 27,
+    OP_IFNE = 28,
+    OP_IFLT = 29,
+    OP_IFLE = 30,
+    OP_IFGT = 31,
+    OP_IFGE = 32,
+    // type conversions
+    OP_I2L = 33,
+    OP_L2I = 34,
+    OP_I2B = 35,
+    OP_I2C = 36,
+    OP_I2S = 37,
+    OP_COUNT = 38  // helper constant with number of opcodes
 };
 
 // Every field of an instruction is lightly encrypted and decoded at


### PR DESCRIPTION
## Summary
- extend VmTranslator and micro VM opcodes to cover bitwise logic, comparison and type conversion instructions
- implement corresponding handlers in micro_vm.cpp and InsnHandler to execute via VM when possible
- try full method translation to VM before falling back to native templates in MethodProcessor

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c40bc36d5083328fcd688f74a00cd2