### PR TITLE
Close generated C++ methods properly

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
@@ -374,6 +374,8 @@ public class MethodProcessor {
         output.append("        }\n");
         output.append("    }\n\n");
 
+        output.append("}\n");
+
         method.localVariables.clear();
         method.tryCatchBlocks.clear();
 


### PR DESCRIPTION
## Summary
- Ensure MethodProcessor appends a final `}` to terminate generated C++ functions

## Testing
- `./gradlew --console=plain assemble`


------
https://chatgpt.com/codex/tasks/task_e_68c41eb658a88332b4b467f0e57055e6