### PR TITLE
Decrypt strings on demand

### DIFF
--- a/obfuscator/src/main/resources/sources/native_jvm_output.cpp
+++ b/obfuscator/src/main/resources/sources/native_jvm_output.cpp
@@ -20,7 +20,6 @@ namespace native_jvm {
             return;
 
         char* string_pool = string_pool::get_pool();
-        string_pool::decrypt_pool();
 
 $register_code
 

--- a/obfuscator/src/main/resources/sources/string_pool.cpp
+++ b/obfuscator/src/main/resources/sources/string_pool.cpp
@@ -42,22 +42,46 @@ namespace native_jvm::string_pool {
         }
     }
 
-    void decrypt_pool() {
+    static void crypt_string(std::size_t offset, std::size_t len) {
         uint32_t key_words[8];
         uint32_t nonce_words[3];
         std::memcpy(key_words, key, 32);
         std::memcpy(nonce_words, nonce, 12);
 
-        size_t len = $size;
+        std::size_t end = offset + len;
         uint32_t block[16];
-        uint32_t counter = 0;
-        for (size_t i = 0; i < len; ) {
+        uint32_t counter = static_cast<uint32_t>(offset / 64);
+        std::size_t i = offset;
+        int j = static_cast<int>(offset % 64);
+
+        chacha_block(block, key_words, nonce_words, counter);
+        unsigned char *stream = reinterpret_cast<unsigned char *>(block);
+        if (j != 0) {
+            for (; j < 64 && i < end; ++j, ++i) {
+                pool[i] ^= static_cast<char>(stream[j]);
+            }
+            counter++;
+        }
+
+        while (i < end) {
             chacha_block(block, key_words, nonce_words, counter++);
-            unsigned char *stream = reinterpret_cast<unsigned char *>(block);
-            for (int j = 0; j < 64 && i < len; ++j, ++i) {
+            stream = reinterpret_cast<unsigned char *>(block);
+            for (j = 0; j < 64 && i < end; ++j, ++i) {
                 pool[i] ^= static_cast<char>(stream[j]);
             }
         }
+    }
+
+    void decrypt_string(std::size_t offset, std::size_t len) {
+        crypt_string(offset, len);
+    }
+
+    void encrypt_string(std::size_t offset, std::size_t len) {
+        crypt_string(offset, len);
+    }
+
+    void clear_string(std::size_t offset, std::size_t len) {
+        std::memset(pool + offset, 0, len);
     }
 
     char *get_pool() {

--- a/obfuscator/src/main/resources/sources/string_pool.hpp
+++ b/obfuscator/src/main/resources/sources/string_pool.hpp
@@ -2,8 +2,12 @@
 
 #define STRING_POOL_HPP_GUARD
 
+#include <cstddef>
+
 namespace native_jvm::string_pool {
-    void decrypt_pool();
+    void decrypt_string(std::size_t offset, std::size_t len);
+    void encrypt_string(std::size_t offset, std::size_t len);
+    void clear_string(std::size_t offset, std::size_t len);
     char *get_pool();
 }
 

--- a/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
@@ -25,10 +25,10 @@ public class StringPoolTest {
     @Test
     public void testGet() {
         StringPool stringPool = new StringPool();
-        assertEquals("((char *)(string_pool + 0LL))", stringPool.get("test"));
-        assertEquals("((char *)(string_pool + 0LL))", stringPool.get("test"));
-        assertEquals("((char *)(string_pool + 5LL))", stringPool.get("\u0080\u0050"));
-        assertEquals("((char *)(string_pool + 9LL))", stringPool.get("\u0800"));
-        assertEquals("((char *)(string_pool + 13LL))", stringPool.get("\u0080"));
+        assertEquals("(string_pool::decrypt_string(0LL, 5), (char *)(string_pool + 0LL))", stringPool.get("test"));
+        assertEquals("(string_pool::decrypt_string(0LL, 5), (char *)(string_pool + 0LL))", stringPool.get("test"));
+        assertEquals("(string_pool::decrypt_string(5LL, 4), (char *)(string_pool + 5LL))", stringPool.get("\u0080\u0050"));
+        assertEquals("(string_pool::decrypt_string(9LL, 4), (char *)(string_pool + 9LL))", stringPool.get("\u0800"));
+        assertEquals("(string_pool::decrypt_string(13LL, 3), (char *)(string_pool + 13LL))", stringPool.get("\u0080"));
     }
 }


### PR DESCRIPTION
## Summary
- Track each string's offset and length in the Java string pool and emit on-demand decryption calls
- Replace whole-pool decryption with `decrypt_string`, adding optional re-encrypt and clear helpers
- Stop globally decrypting the pool in generated C++ output

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c433344d508332b3576c0534c65d09