### PR TITLE
Use per-entry keys and nonces in string pool encryption

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/source/StringPool.java
+++ b/obfuscator/src/main/java/by/radioegor146/source/StringPool.java
@@ -2,6 +2,7 @@ package by.radioegor146.source;
 
 import by.radioegor146.Util;
 
+import java.security.SecureRandom;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -11,38 +12,37 @@ public class StringPool {
     private static class Entry {
         long offset;
         int length;
+        byte[] key;
+        byte[] nonce;
 
-        Entry(long offset, int length) {
+        Entry(long offset, int length, byte[] key, byte[] nonce) {
             this.offset = offset;
             this.length = length;
+            this.key = key;
+            this.nonce = nonce;
         }
     }
 
     private long length;
     private final Map<String, Entry> pool;
 
-    private static final byte[] KEY = new byte[]{
-            0, 1, 2, 3, 4, 5, 6, 7,
-            8, 9, 10, 11, 12, 13, 14, 15,
-            16, 17, 18, 19, 20, 21, 22, 23,
-            24, 25, 26, 27, 28, 29, 30, 31
-    };
-    private static final byte[] NONCE = new byte[]{
-            0, 0, 0, 9,
-            0, 0, 0, 74,
-            0, 0, 0, 0
-    };
+    private final SecureRandom random;
 
     public StringPool() {
         this.length = 0;
         this.pool = new HashMap<>();
+        this.random = new SecureRandom();
     }
 
     public String get(String value) {
         Entry entry = pool.get(value);
         if (entry == null) {
             byte[] bytes = getModifiedUtf8Bytes(value);
-            entry = new Entry(length, bytes.length + 1);
+            byte[] key = new byte[32];
+            byte[] nonce = new byte[12];
+            random.nextBytes(key);
+            random.nextBytes(nonce);
+            entry = new Entry(length, bytes.length + 1, key, nonce);
             pool.put(value, entry);
             length += entry.length;
         }
@@ -106,34 +106,40 @@ public class StringPool {
     }
 
     public String build() {
-        List<Byte> plainBytes = new ArrayList<>();
+        List<Byte> encryptedBytes = new ArrayList<>();
+        List<String> entries = new ArrayList<>();
         pool.entrySet().stream()
                 .sorted(Comparator.comparingLong(e -> e.getValue().offset))
-                .map(Map.Entry::getKey)
-                .forEach(string -> {
-                    for (byte b : getModifiedUtf8Bytes(string)) {
-                        plainBytes.add(b);
+                .forEach(e -> {
+                    String string = e.getKey();
+                    Entry entry = e.getValue();
+                    byte[] bytes = getModifiedUtf8Bytes(string);
+                    byte[] plain = Arrays.copyOf(bytes, bytes.length + 1);
+                    byte[] encrypted = ChaCha20.crypt(entry.key, entry.nonce, 0, plain);
+                    for (byte b : encrypted) {
+                        encryptedBytes.add(b);
                     }
-                    plainBytes.add((byte) 0);
+                    entries.add(String.format("{ %dLL, %s, %s }", entry.offset,
+                            formatArray(entry.key), formatArray(entry.nonce)));
                 });
 
-        byte[] plain = new byte[plainBytes.size()];
-        for (int i = 0; i < plainBytes.size(); i++) {
-            plain[i] = plainBytes.get(i);
+        byte[] encrypted = new byte[encryptedBytes.size()];
+        for (int i = 0; i < encryptedBytes.size(); i++) {
+            encrypted[i] = encryptedBytes.get(i);
         }
-        byte[] encrypted = ChaCha20.crypt(KEY, NONCE, 0, plain);
 
-        String result = String.format("{ %s }", IntStream.range(0, encrypted.length)
+        String poolArray = String.format("{ %s }", IntStream.range(0, encrypted.length)
                 .map(i -> encrypted[i] & 0xFF)
                 .mapToObj(String::valueOf)
                 .collect(Collectors.joining(", ")));
 
+        String entriesArray = entries.stream().collect(Collectors.joining(", "));
+
         String template = Util.readResource("sources/string_pool.cpp");
         return Util.dynamicFormat(template, Util.createMap(
                 "size", Math.max(1, encrypted.length) + "LL",
-                "value", result,
-                "key", formatArray(KEY),
-                "nonce", formatArray(NONCE)
+                "value", poolArray,
+                "entries", entriesArray
         ));
     }
 

--- a/obfuscator/src/main/resources/sources/string_pool.cpp
+++ b/obfuscator/src/main/resources/sources/string_pool.cpp
@@ -4,8 +4,7 @@
 #include <cstring>
 
 namespace native_jvm::string_pool {
-    static unsigned char key[32] = $key;
-    static unsigned char nonce[12] = $nonce;
+    static entry entries[] = { $entries };
     static char pool[$size] = $value;
     static unsigned char decrypted[$size] = {};
 
@@ -43,32 +42,34 @@ namespace native_jvm::string_pool {
         }
     }
 
+    static entry *find_entry(std::size_t offset) {
+        for (auto &e : entries) {
+            if (e.offset == offset) {
+                return &e;
+            }
+        }
+        return nullptr;
+    }
+
     static void crypt_string(std::size_t offset, std::size_t len) {
+        entry *e = find_entry(offset);
+        if (e == nullptr) {
+            return;
+        }
         uint32_t key_words[8];
         uint32_t nonce_words[3];
-        std::memcpy(key_words, key, 32);
-        std::memcpy(nonce_words, nonce, 12);
+        std::memcpy(key_words, e->key, 32);
+        std::memcpy(nonce_words, e->nonce, 12);
 
-        std::size_t end = offset + len;
         uint32_t block[16];
-        uint32_t counter = static_cast<uint32_t>(offset / 64);
-        std::size_t i = offset;
-        int j = static_cast<int>(offset % 64);
-
-        chacha_block(block, key_words, nonce_words, counter);
-        unsigned char *stream = reinterpret_cast<unsigned char *>(block);
-        if (j != 0) {
-            for (; j < 64 && i < end; ++j, ++i) {
-                pool[i] ^= static_cast<char>(stream[j]);
-            }
-            counter++;
-        }
-
-        while (i < end) {
+        uint32_t counter = 0;
+        std::size_t i = 0;
+        unsigned char *stream;
+        while (i < len) {
             chacha_block(block, key_words, nonce_words, counter++);
             stream = reinterpret_cast<unsigned char *>(block);
-            for (j = 0; j < 64 && i < end; ++j, ++i) {
-                pool[i] ^= static_cast<char>(stream[j]);
+            for (std::size_t j = 0; j < 64 && i < len; ++j, ++i) {
+                pool[offset + i] ^= static_cast<char>(stream[j]);
             }
         }
     }
@@ -96,3 +97,4 @@ namespace native_jvm::string_pool {
         return pool;
     }
 }
+

--- a/obfuscator/src/main/resources/sources/string_pool.hpp
+++ b/obfuscator/src/main/resources/sources/string_pool.hpp
@@ -5,6 +5,12 @@
 #include <cstddef>
 
 namespace native_jvm::string_pool {
+    struct entry {
+        std::size_t offset;
+        unsigned char key[32];
+        unsigned char nonce[12];
+    };
+
     void decrypt_string(std::size_t offset, std::size_t len);
     void encrypt_string(std::size_t offset, std::size_t len);
     void clear_string(std::size_t offset, std::size_t len);

--- a/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
@@ -1,8 +1,14 @@
 package by.radioegor146.source;
 
+import by.radioegor146.source.ChaCha20;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StringPoolTest {
 
@@ -13,13 +19,14 @@ public class StringPoolTest {
         stringPool.get("test");
 
         String build1 = stringPool.build();
-        org.junit.jupiter.api.Assertions.assertTrue(build1.contains("static unsigned char key[32]"));
-        org.junit.jupiter.api.Assertions.assertTrue(build1.contains("static char pool[5LL] = { 254, 185, 226, 137, 159 };"));
+        assertTrue(build1.contains("static char pool[5LL]"));
+        assertTrue(build1.contains("entries[] = { { 0LL"));
 
         stringPool.get("other");
 
         String build2 = stringPool.build();
-        org.junit.jupiter.api.Assertions.assertTrue(build2.contains("static char pool[11LL] = { 254, 185, 226, 137, 159, 155, 132, 157, 126, 125, 173 };"));
+        assertTrue(build2.contains("static char pool[11LL]"));
+        assertTrue(build2.contains("{ 5LL"));
     }
 
     @Test
@@ -30,5 +37,45 @@ public class StringPoolTest {
         assertEquals("(string_pool::decrypt_string(5LL, 4), (char *)(string_pool + 5LL))", stringPool.get("\u0080\u0050"));
         assertEquals("(string_pool::decrypt_string(9LL, 4), (char *)(string_pool + 9LL))", stringPool.get("\u0800"));
         assertEquals("(string_pool::decrypt_string(13LL, 3), (char *)(string_pool + 13LL))", stringPool.get("\u0080"));
+    }
+
+    @Test
+    public void testRandomEncryptionAndCrypt() throws Exception {
+        StringPool pool1 = new StringPool();
+        pool1.get("test");
+        StringPool pool2 = new StringPool();
+        pool2.get("test");
+
+        byte[] key1 = getEntryField(pool1, "test", "key");
+        byte[] nonce1 = getEntryField(pool1, "test", "nonce");
+        byte[] key2 = getEntryField(pool2, "test", "key");
+        byte[] nonce2 = getEntryField(pool2, "test", "nonce");
+
+        byte[] plain = getPlainBytes("test");
+
+        byte[] enc1 = ChaCha20.crypt(key1, nonce1, 0, plain);
+        byte[] enc2 = ChaCha20.crypt(key2, nonce2, 0, plain);
+        assertFalse(Arrays.equals(enc1, enc2));
+        byte[] dec1 = ChaCha20.crypt(key1, nonce1, 0, enc1);
+        assertArrayEquals(plain, dec1);
+        assertArrayEquals(enc1, ChaCha20.crypt(key1, nonce1, 0, dec1));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static byte[] getEntryField(StringPool pool, String value, String field) throws Exception {
+        Field poolField = StringPool.class.getDeclaredField("pool");
+        poolField.setAccessible(true);
+        Map<String, Object> map = (Map<String, Object>) poolField.get(pool);
+        Object entry = map.get(value);
+        Field f = entry.getClass().getDeclaredField(field);
+        f.setAccessible(true);
+        return (byte[]) f.get(entry);
+    }
+
+    private static byte[] getPlainBytes(String value) throws Exception {
+        Method m = StringPool.class.getDeclaredMethod("getModifiedUtf8Bytes", String.class);
+        m.setAccessible(true);
+        byte[] bytes = (byte[]) m.invoke(null, value);
+        return Arrays.copyOf(bytes, bytes.length + 1);
     }
 }


### PR DESCRIPTION
## Summary
- Assign each pooled string its own random 32-byte key and 12-byte nonce generated with SecureRandom
- Encrypt strings independently and record offsets with associated keys/nonces in C++ entry table
- Verify randomised encryption and decrypt/encrypt behaviour through new StringPool tests

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c43abcc0d0833285653ba60df3c96c