### PR TITLE
Inline key and nonce in string pool decryption

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/source/StringPool.java
+++ b/obfuscator/src/main/java/by/radioegor146/source/StringPool.java
@@ -46,8 +46,8 @@ public class StringPool {
             pool.put(value, entry);
             length += entry.length;
         }
-        return String.format("(string_pool::decrypt_string(%dLL, %d), (char *)(string_pool + %dLL))",
-                entry.offset, entry.length, entry.offset);
+        return String.format("([](){ unsigned char key[32] = %s; unsigned char nonce[12] = %s; string_pool::decrypt_string(%dLL, %d, key, nonce); return (char *)(string_pool + %dLL); })()",
+                formatArray(entry.key), formatArray(entry.nonce), entry.offset, entry.length, entry.offset);
     }
 
     public long getOffset(String value) {
@@ -107,7 +107,6 @@ public class StringPool {
 
     public String build() {
         List<Byte> encryptedBytes = new ArrayList<>();
-        List<String> entries = new ArrayList<>();
         pool.entrySet().stream()
                 .sorted(Comparator.comparingLong(e -> e.getValue().offset))
                 .forEach(e -> {
@@ -119,8 +118,6 @@ public class StringPool {
                     for (byte b : encrypted) {
                         encryptedBytes.add(b);
                     }
-                    entries.add(String.format("{ %dLL, %s, %s }", entry.offset,
-                            formatArray(entry.key), formatArray(entry.nonce)));
                 });
 
         byte[] encrypted = new byte[encryptedBytes.size()];
@@ -133,18 +130,10 @@ public class StringPool {
                 .mapToObj(String::valueOf)
                 .collect(Collectors.joining(", ")));
 
-        String entriesArray;
-        if (entries.isEmpty()) {
-            entriesArray = "{ 0LL, { 0 }, { 0 } }";
-        } else {
-            entriesArray = entries.stream().collect(Collectors.joining(", "));
-        }
-
         String template = Util.readResource("sources/string_pool.cpp");
         return Util.dynamicFormat(template, Util.createMap(
                 "size", Math.max(1, encrypted.length) + "LL",
-                "value", poolArray,
-                "entries", entriesArray
+                "value", poolArray
         ));
     }
 

--- a/obfuscator/src/main/resources/sources/string_pool.hpp
+++ b/obfuscator/src/main/resources/sources/string_pool.hpp
@@ -5,14 +5,8 @@
 #include <cstddef>
 
 namespace native_jvm::string_pool {
-    struct entry {
-        std::size_t offset;
-        unsigned char key[32];
-        unsigned char nonce[12];
-    };
-
-    void decrypt_string(std::size_t offset, std::size_t len);
-    void encrypt_string(std::size_t offset, std::size_t len);
+    void decrypt_string(std::size_t offset, std::size_t len, const unsigned char key[32], const unsigned char nonce[12]);
+    void encrypt_string(std::size_t offset, std::size_t len, const unsigned char key[32], const unsigned char nonce[12]);
     void clear_string(std::size_t offset, std::size_t len);
     char *get_pool();
 }

--- a/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
@@ -20,23 +20,37 @@ public class StringPoolTest {
 
         String build1 = stringPool.build();
         assertTrue(build1.contains("static char pool[5LL]"));
-        assertTrue(build1.contains("entries[] = { { 0LL"));
+        assertFalse(build1.contains("entries[]"));
 
         stringPool.get("other");
 
         String build2 = stringPool.build();
         assertTrue(build2.contains("static char pool[11LL]"));
-        assertTrue(build2.contains("{ 5LL"));
+        assertFalse(build2.contains("entries[]"));
     }
 
     @Test
     public void testGet() {
         StringPool stringPool = new StringPool();
-        assertEquals("(string_pool::decrypt_string(0LL, 5), (char *)(string_pool + 0LL))", stringPool.get("test"));
-        assertEquals("(string_pool::decrypt_string(0LL, 5), (char *)(string_pool + 0LL))", stringPool.get("test"));
-        assertEquals("(string_pool::decrypt_string(5LL, 4), (char *)(string_pool + 5LL))", stringPool.get("\u0080\u0050"));
-        assertEquals("(string_pool::decrypt_string(9LL, 4), (char *)(string_pool + 9LL))", stringPool.get("\u0800"));
-        assertEquals("(string_pool::decrypt_string(13LL, 3), (char *)(string_pool + 13LL))", stringPool.get("\u0080"));
+        String r1 = stringPool.get("test");
+        assertTrue(r1.startsWith("([](){ unsigned char key[32]"));
+        assertTrue(r1.contains("string_pool::decrypt_string(0LL, 5, key, nonce)"));
+        assertTrue(r1.endsWith("(char *)(string_pool + 0LL); })()"));
+
+        String r2 = stringPool.get("test");
+        assertTrue(r2.contains("string_pool::decrypt_string(0LL, 5, key, nonce)"));
+
+        String r3 = stringPool.get("\u0080\u0050");
+        assertTrue(r3.contains("string_pool::decrypt_string(5LL, 4, key, nonce)"));
+        assertTrue(r3.endsWith("(char *)(string_pool + 5LL); })()"));
+
+        String r4 = stringPool.get("\u0800");
+        assertTrue(r4.contains("string_pool::decrypt_string(9LL, 4, key, nonce)"));
+        assertTrue(r4.endsWith("(char *)(string_pool + 9LL); })()"));
+
+        String r5 = stringPool.get("\u0080");
+        assertTrue(r5.contains("string_pool::decrypt_string(13LL, 3, key, nonce)"));
+        assertTrue(r5.endsWith("(char *)(string_pool + 13LL); })()"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- remove global entry table and pass ChaCha key and nonce directly when decrypting strings
- generate C++ lambdas that carry per-string key/nonce arrays
- update tests for new string pool API

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c4445826188332acf2b7abb63bfc7e