### PR TITLE
Refactor string pool API to accept key and nonce

### DIFF
--- a/obfuscator/src/main/resources/sources/string_pool.cpp
+++ b/obfuscator/src/main/resources/sources/string_pool.cpp
@@ -4,7 +4,6 @@
 #include <cstring>
 
 namespace native_jvm::string_pool {
-    static entry entries[] = { $entries };
     static char pool[$size] = $value;
     static unsigned char decrypted[$size] = {};
 
@@ -42,24 +41,12 @@ namespace native_jvm::string_pool {
         }
     }
 
-    static entry *find_entry(std::size_t offset) {
-        for (auto &e : entries) {
-            if (e.offset == offset) {
-                return &e;
-            }
-        }
-        return nullptr;
-    }
-
-    static void crypt_string(std::size_t offset, std::size_t len) {
-        entry *e = find_entry(offset);
-        if (e == nullptr) {
-            return;
-        }
+    static void crypt_string(const unsigned char key[32], const unsigned char nonce[12],
+                             std::size_t offset, std::size_t len) {
         uint32_t key_words[8];
         uint32_t nonce_words[3];
-        std::memcpy(key_words, e->key, 32);
-        std::memcpy(nonce_words, e->nonce, 12);
+        std::memcpy(key_words, key, 32);
+        std::memcpy(nonce_words, nonce, 12);
 
         uint32_t block[16];
         uint32_t counter = 0;
@@ -74,16 +61,18 @@ namespace native_jvm::string_pool {
         }
     }
 
-    void decrypt_string(std::size_t offset, std::size_t len) {
+    void decrypt_string(const unsigned char key[32], const unsigned char nonce[12],
+                        std::size_t offset, std::size_t len) {
         if (!decrypted[offset]) {
-            crypt_string(offset, len);
+            crypt_string(key, nonce, offset, len);
             std::memset(decrypted + offset, 1, len);
         }
     }
 
-    void encrypt_string(std::size_t offset, std::size_t len) {
+    void encrypt_string(const unsigned char key[32], const unsigned char nonce[12],
+                        std::size_t offset, std::size_t len) {
         if (decrypted[offset]) {
-            crypt_string(offset, len);
+            crypt_string(key, nonce, offset, len);
             std::memset(decrypted + offset, 0, len);
         }
     }

--- a/obfuscator/src/main/resources/sources/string_pool.hpp
+++ b/obfuscator/src/main/resources/sources/string_pool.hpp
@@ -5,14 +5,10 @@
 #include <cstddef>
 
 namespace native_jvm::string_pool {
-    struct entry {
-        std::size_t offset;
-        unsigned char key[32];
-        unsigned char nonce[12];
-    };
-
-    void decrypt_string(std::size_t offset, std::size_t len);
-    void encrypt_string(std::size_t offset, std::size_t len);
+    void decrypt_string(const unsigned char key[32], const unsigned char nonce[12],
+                        std::size_t offset, std::size_t len);
+    void encrypt_string(const unsigned char key[32], const unsigned char nonce[12],
+                        std::size_t offset, std::size_t len);
     void clear_string(std::size_t offset, std::size_t len);
     char *get_pool();
 }

--- a/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
@@ -20,23 +20,35 @@ public class StringPoolTest {
 
         String build1 = stringPool.build();
         assertTrue(build1.contains("static char pool[5LL]"));
-        assertTrue(build1.contains("entries[] = { { 0LL"));
+        assertTrue(build1.contains("static unsigned char decrypted[5LL]"));
+        assertFalse(build1.contains("entries"));
 
         stringPool.get("other");
 
         String build2 = stringPool.build();
         assertTrue(build2.contains("static char pool[11LL]"));
-        assertTrue(build2.contains("{ 5LL"));
+        assertTrue(build2.contains("static unsigned char decrypted[11LL]"));
     }
 
     @Test
     public void testGet() {
         StringPool stringPool = new StringPool();
-        assertEquals("(string_pool::decrypt_string(0LL, 5), (char *)(string_pool + 0LL))", stringPool.get("test"));
-        assertEquals("(string_pool::decrypt_string(0LL, 5), (char *)(string_pool + 0LL))", stringPool.get("test"));
-        assertEquals("(string_pool::decrypt_string(5LL, 4), (char *)(string_pool + 5LL))", stringPool.get("\u0080\u0050"));
-        assertEquals("(string_pool::decrypt_string(9LL, 4), (char *)(string_pool + 9LL))", stringPool.get("\u0800"));
-        assertEquals("(string_pool::decrypt_string(13LL, 3), (char *)(string_pool + 13LL))", stringPool.get("\u0080"));
+        String res1 = stringPool.get("test");
+        assertTrue(res1.startsWith("(string_pool::decrypt_string("));
+        assertTrue(res1.endsWith(", 0LL, 5), (char *)(string_pool + 0LL))"));
+        assertEquals(res1, stringPool.get("test"));
+
+        String res3 = stringPool.get("\u0080\u0050");
+        assertTrue(res3.startsWith("(string_pool::decrypt_string("));
+        assertTrue(res3.endsWith(", 5LL, 4), (char *)(string_pool + 5LL))"));
+
+        String res4 = stringPool.get("\u0800");
+        assertTrue(res4.startsWith("(string_pool::decrypt_string("));
+        assertTrue(res4.endsWith(", 9LL, 4), (char *)(string_pool + 9LL))"));
+
+        String res5 = stringPool.get("\u0080");
+        assertTrue(res5.startsWith("(string_pool::decrypt_string("));
+        assertTrue(res5.endsWith(", 13LL, 3), (char *)(string_pool + 13LL))"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- remove entry struct and entries table from string pool template
- pass key and nonce directly to encrypt/decrypt functions and underlying `crypt_string`
- update generator and tests for the new API

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c44c1b9f248332a2701afb5bac1574