### PR TITLE
Use seeded constant encoding for string pool decryption

### DIFF
--- a/obfuscator/src/main/resources/sources/string_pool.hpp
+++ b/obfuscator/src/main/resources/sources/string_pool.hpp
@@ -3,12 +3,13 @@
 #define STRING_POOL_HPP_GUARD
 
 #include <cstddef>
+#include <cstdint>
 
 namespace native_jvm::string_pool {
     void decrypt_string(const unsigned char key[32], const unsigned char nonce[12],
-                        std::size_t offset, std::size_t len);
+                        uint32_t seed, std::size_t offset, std::size_t len);
     void encrypt_string(const unsigned char key[32], const unsigned char nonce[12],
-                        std::size_t offset, std::size_t len);
+                        uint32_t seed, std::size_t offset, std::size_t len);
     void clear_string(std::size_t offset, std::size_t len);
     char *get_pool();
 }

--- a/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
@@ -36,6 +36,10 @@ public class StringPoolTest {
         String res1 = stringPool.get("test");
         assertTrue(res1.startsWith("(string_pool::decrypt_string("));
         assertTrue(res1.endsWith(", 0LL, 5), (char *)(string_pool + 0LL))"));
+        int afterArrays = res1.lastIndexOf("}(), ");
+        assertTrue(afterArrays > 0);
+        String rest = res1.substring(afterArrays + 5);
+        assertTrue(rest.matches("-?\\d+, 0LL, 5\\), \\(char \\*\\)\\(string_pool \\+ 0LL\\)\\)"));
         assertEquals(res1, stringPool.get("test"));
         assertFalse(res1.contains("(unsigned char[]){"));
 


### PR DESCRIPTION
## Summary
- Add random seed to `StringPool` entries and encode key/nonce bytes before code generation
- Decode key/nonce at runtime by passing the seed to `string_pool::decrypt_string`
- Update tests to cover new seed-aware string pool API

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c451ebd99c83328c1b52474e612927