### PR TITLE
feat: obfuscate key nonce decoding

### DIFF
--- a/obfuscator/src/main/resources/sources/string_pool.hpp
+++ b/obfuscator/src/main/resources/sources/string_pool.hpp
@@ -6,6 +6,8 @@
 #include <cstdint>
 
 namespace native_jvm::string_pool {
+    unsigned char *decode_key(const unsigned char in[32], uint32_t seed);
+    unsigned char *decode_nonce(const unsigned char in[12], uint32_t seed);
     void decrypt_string(const unsigned char key[32], const unsigned char nonce[12],
                         uint32_t seed, std::size_t offset, std::size_t len);
     void encrypt_string(const unsigned char key[32], const unsigned char nonce[12],


### PR DESCRIPTION
## Summary
- obfuscate key/nonce decoding via micro-VM and flattened control flow
- wipe decoded key/nonce buffers after use

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c4572b6234833295e93bdf0d6764d0