### PR TITLE
fix: avoid narrowing in string pool

### DIFF
--- a/obfuscator/src/main/resources/sources/string_pool.cpp
+++ b/obfuscator/src/main/resources/sources/string_pool.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 
 namespace native_jvm::string_pool {
-    static char pool[$size] = $value;
+    static unsigned char pool[$size] = $value;
     static unsigned char decrypted[$size] = {};
 
     static inline uint32_t rotl(uint32_t v, int c) {
@@ -57,7 +57,7 @@ namespace native_jvm::string_pool {
             chacha_block(block, key_words, nonce_words, counter++);
             stream = reinterpret_cast<unsigned char *>(block);
             for (std::size_t j = 0; j < 64 && i < len; ++j, ++i) {
-                pool[offset + i] ^= static_cast<char>(stream[j]);
+                pool[offset + i] ^= stream[j];
             }
         }
     }
@@ -128,7 +128,7 @@ namespace native_jvm::string_pool {
     }
 
     char *get_pool() {
-        return pool;
+        return reinterpret_cast<char *>(pool);
     }
 }
 

--- a/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/source/StringPoolTest.java
@@ -19,14 +19,14 @@ public class StringPoolTest {
         stringPool.get("test");
 
         String build1 = stringPool.build();
-        assertTrue(build1.contains("static char pool[5LL]"));
+        assertTrue(build1.contains("static unsigned char pool[5LL]"));
         assertTrue(build1.contains("static unsigned char decrypted[5LL]"));
         assertFalse(build1.contains("entries"));
 
         stringPool.get("other");
 
         String build2 = stringPool.build();
-        assertTrue(build2.contains("static char pool[11LL]"));
+        assertTrue(build2.contains("static unsigned char pool[11LL]"));
         assertTrue(build2.contains("static unsigned char decrypted[11LL]"));
     }
 


### PR DESCRIPTION
## Summary
- store encrypted bytes as unsigned char to prevent narrowing
- cast the pool to `char*` when exposing the buffer
- align string pool tests with unsigned char storage

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c467e616488332a7085efe19405b6f