### PR TITLE
Support long/float/double ops in VM

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -81,6 +81,24 @@ public class VmTranslator {
         public static final int OP_AALOAD = 34;
         public static final int OP_AASTORE = 35;
         public static final int OP_INVOKESTATIC = 36;
+        public static final int OP_LLOAD = 37;
+        public static final int OP_FLOAD = 38;
+        public static final int OP_DLOAD = 39;
+        public static final int OP_LSTORE = 40;
+        public static final int OP_FSTORE = 41;
+        public static final int OP_DSTORE = 42;
+        public static final int OP_LADD = 43;
+        public static final int OP_LSUB = 44;
+        public static final int OP_LMUL = 45;
+        public static final int OP_LDIV = 46;
+        public static final int OP_FADD = 47;
+        public static final int OP_FSUB = 48;
+        public static final int OP_FMUL = 49;
+        public static final int OP_FDIV = 50;
+        public static final int OP_DADD = 51;
+        public static final int OP_DSUB = 52;
+        public static final int OP_DMUL = 53;
+        public static final int OP_DDIV = 54;
     }
 
     /**
@@ -113,17 +131,80 @@ public class VmTranslator {
                 case 29: // ILOAD_3
                     result.add(new Instruction(VmOpcodes.OP_LOAD, opcode - 26));
                     break;
+                case Opcodes.LLOAD:
+                    result.add(new Instruction(VmOpcodes.OP_LLOAD, ((VarInsnNode) insn).var));
+                    break;
+                case 30: // LLOAD_0
+                case 31: // LLOAD_1
+                case 32: // LLOAD_2
+                case 33: // LLOAD_3
+                    result.add(new Instruction(VmOpcodes.OP_LLOAD, opcode - 30));
+                    break;
+                case Opcodes.FLOAD:
+                    result.add(new Instruction(VmOpcodes.OP_FLOAD, ((VarInsnNode) insn).var));
+                    break;
+                case 34: // FLOAD_0
+                case 35: // FLOAD_1
+                case 36: // FLOAD_2
+                case 37: // FLOAD_3
+                    result.add(new Instruction(VmOpcodes.OP_FLOAD, opcode - 34));
+                    break;
+                case Opcodes.DLOAD:
+                    result.add(new Instruction(VmOpcodes.OP_DLOAD, ((VarInsnNode) insn).var));
+                    break;
+                case 38: // DLOAD_0
+                case 39: // DLOAD_1
+                case 40: // DLOAD_2
+                case 41: // DLOAD_3
+                    result.add(new Instruction(VmOpcodes.OP_DLOAD, opcode - 38));
+                    break;
                 case Opcodes.IADD:
                     result.add(new Instruction(VmOpcodes.OP_ADD, 0));
+                    break;
+                case Opcodes.LADD:
+                    result.add(new Instruction(VmOpcodes.OP_LADD, 0));
+                    break;
+                case Opcodes.FADD:
+                    result.add(new Instruction(VmOpcodes.OP_FADD, 0));
+                    break;
+                case Opcodes.DADD:
+                    result.add(new Instruction(VmOpcodes.OP_DADD, 0));
                     break;
                 case Opcodes.ISUB:
                     result.add(new Instruction(VmOpcodes.OP_SUB, 0));
                     break;
+                case Opcodes.LSUB:
+                    result.add(new Instruction(VmOpcodes.OP_LSUB, 0));
+                    break;
+                case Opcodes.FSUB:
+                    result.add(new Instruction(VmOpcodes.OP_FSUB, 0));
+                    break;
+                case Opcodes.DSUB:
+                    result.add(new Instruction(VmOpcodes.OP_DSUB, 0));
+                    break;
                 case Opcodes.IMUL:
                     result.add(new Instruction(VmOpcodes.OP_MUL, 0));
                     break;
+                case Opcodes.LMUL:
+                    result.add(new Instruction(VmOpcodes.OP_LMUL, 0));
+                    break;
+                case Opcodes.FMUL:
+                    result.add(new Instruction(VmOpcodes.OP_FMUL, 0));
+                    break;
+                case Opcodes.DMUL:
+                    result.add(new Instruction(VmOpcodes.OP_DMUL, 0));
+                    break;
                 case Opcodes.IDIV:
                     result.add(new Instruction(VmOpcodes.OP_DIV, 0));
+                    break;
+                case Opcodes.LDIV:
+                    result.add(new Instruction(VmOpcodes.OP_LDIV, 0));
+                    break;
+                case Opcodes.FDIV:
+                    result.add(new Instruction(VmOpcodes.OP_FDIV, 0));
+                    break;
+                case Opcodes.DDIV:
+                    result.add(new Instruction(VmOpcodes.OP_DDIV, 0));
                     break;
                 case Opcodes.IAND:
                     result.add(new Instruction(VmOpcodes.OP_AND, 0));
@@ -191,6 +272,33 @@ public class VmTranslator {
                 case 62: // ISTORE_3
                     result.add(new Instruction(VmOpcodes.OP_STORE, opcode - 59));
                     break;
+                case Opcodes.LSTORE:
+                    result.add(new Instruction(VmOpcodes.OP_LSTORE, ((VarInsnNode) insn).var));
+                    break;
+                case 63: // LSTORE_0
+                case 64: // LSTORE_1
+                case 65: // LSTORE_2
+                case 66: // LSTORE_3
+                    result.add(new Instruction(VmOpcodes.OP_LSTORE, opcode - 63));
+                    break;
+                case Opcodes.FSTORE:
+                    result.add(new Instruction(VmOpcodes.OP_FSTORE, ((VarInsnNode) insn).var));
+                    break;
+                case 67: // FSTORE_0
+                case 68: // FSTORE_1
+                case 69: // FSTORE_2
+                case 70: // FSTORE_3
+                    result.add(new Instruction(VmOpcodes.OP_FSTORE, opcode - 67));
+                    break;
+                case Opcodes.DSTORE:
+                    result.add(new Instruction(VmOpcodes.OP_DSTORE, ((VarInsnNode) insn).var));
+                    break;
+                case 71: // DSTORE_0
+                case 72: // DSTORE_1
+                case 73: // DSTORE_2
+                case 74: // DSTORE_3
+                    result.add(new Instruction(VmOpcodes.OP_DSTORE, opcode - 71));
+                    break;
                 case Opcodes.GOTO:
                     result.add(new Instruction(VmOpcodes.OP_GOTO, labelIds.get(((JumpInsnNode) insn).label)));
                     break;
@@ -213,6 +321,9 @@ public class VmTranslator {
                     result.add(new Instruction(VmOpcodes.OP_IF_ICMPGE, labelIds.get(((JumpInsnNode) insn).label)));
                     break;
                 case Opcodes.IRETURN:
+                case Opcodes.LRETURN:
+                case Opcodes.FRETURN:
+                case Opcodes.DRETURN:
                     result.add(new Instruction(VmOpcodes.OP_HALT, 0));
                     break;
                 case Opcodes.ARETURN:

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <vector>
 #include <unordered_map>
+#include <cstring>
 
 // NOLINTBEGIN - obfuscated control flow by design
 namespace native_jvm::vm {
@@ -127,7 +128,13 @@ dispatch:
         case OP_SWAP:  goto do_swap;
         case OP_DUP:   goto do_dup;
         case OP_LOAD:  goto do_load;
+        case OP_LLOAD:
+        case OP_FLOAD:
+        case OP_DLOAD: goto do_load;
         case OP_STORE: goto do_store;
+        case OP_LSTORE:
+        case OP_FSTORE:
+        case OP_DSTORE: goto do_store;
         case OP_IF_ICMPEQ: goto do_if_icmpeq;
         case OP_IF_ICMPNE: goto do_if_icmpne;
         case OP_GOTO:  goto do_goto;
@@ -150,6 +157,18 @@ dispatch:
         case OP_ASTORE: goto do_astore;
         case OP_AALOAD: goto do_aaload;
         case OP_AASTORE: goto do_aastore;
+        case OP_LADD: goto do_add;
+        case OP_LSUB: goto do_sub;
+        case OP_LMUL: goto do_mul;
+        case OP_LDIV: goto do_div;
+        case OP_FADD: goto do_fadd;
+        case OP_FSUB: goto do_fsub;
+        case OP_FMUL: goto do_fmul;
+        case OP_FDIV: goto do_fdiv;
+        case OP_DADD: goto do_dadd;
+        case OP_DSUB: goto do_dsub;
+        case OP_DMUL: goto do_dmul;
+        case OP_DDIV: goto do_ddiv;
         case OP_INVOKESTATIC: goto do_invokestatic;
         default:       goto halt;
     }
@@ -181,6 +200,118 @@ do_div:
             goto halt;
         }
         stack[sp - 2] /= b;
+        --sp;
+    }
+    goto dispatch;
+
+do_fadd:
+    if (sp >= 2) {
+        float a, b, r;
+        int32_t ba = static_cast<int32_t>(stack[sp - 2]);
+        int32_t bb = static_cast<int32_t>(stack[sp - 1]);
+        std::memcpy(&a, &ba, sizeof(float));
+        std::memcpy(&b, &bb, sizeof(float));
+        r = a + b;
+        std::memcpy(&ba, &r, sizeof(float));
+        stack[sp - 2] = static_cast<int64_t>(ba);
+        --sp;
+    }
+    goto dispatch;
+
+do_fsub:
+    if (sp >= 2) {
+        float a, b, r;
+        int32_t ba = static_cast<int32_t>(stack[sp - 2]);
+        int32_t bb = static_cast<int32_t>(stack[sp - 1]);
+        std::memcpy(&a, &ba, sizeof(float));
+        std::memcpy(&b, &bb, sizeof(float));
+        r = a - b;
+        std::memcpy(&ba, &r, sizeof(float));
+        stack[sp - 2] = static_cast<int64_t>(ba);
+        --sp;
+    }
+    goto dispatch;
+
+do_fmul:
+    if (sp >= 2) {
+        float a, b, r;
+        int32_t ba = static_cast<int32_t>(stack[sp - 2]);
+        int32_t bb = static_cast<int32_t>(stack[sp - 1]);
+        std::memcpy(&a, &ba, sizeof(float));
+        std::memcpy(&b, &bb, sizeof(float));
+        r = a * b;
+        std::memcpy(&ba, &r, sizeof(float));
+        stack[sp - 2] = static_cast<int64_t>(ba);
+        --sp;
+    }
+    goto dispatch;
+
+do_fdiv:
+    if (sp >= 2) {
+        float a, b, r;
+        int32_t ba = static_cast<int32_t>(stack[sp - 2]);
+        int32_t bb = static_cast<int32_t>(stack[sp - 1]);
+        std::memcpy(&a, &ba, sizeof(float));
+        std::memcpy(&b, &bb, sizeof(float));
+        r = a / b;
+        std::memcpy(&ba, &r, sizeof(float));
+        stack[sp - 2] = static_cast<int64_t>(ba);
+        --sp;
+    }
+    goto dispatch;
+
+do_dadd:
+    if (sp >= 2) {
+        double a, b, r;
+        int64_t ba = stack[sp - 2];
+        int64_t bb = stack[sp - 1];
+        std::memcpy(&a, &ba, sizeof(double));
+        std::memcpy(&b, &bb, sizeof(double));
+        r = a + b;
+        std::memcpy(&ba, &r, sizeof(double));
+        stack[sp - 2] = ba;
+        --sp;
+    }
+    goto dispatch;
+
+do_dsub:
+    if (sp >= 2) {
+        double a, b, r;
+        int64_t ba = stack[sp - 2];
+        int64_t bb = stack[sp - 1];
+        std::memcpy(&a, &ba, sizeof(double));
+        std::memcpy(&b, &bb, sizeof(double));
+        r = a - b;
+        std::memcpy(&ba, &r, sizeof(double));
+        stack[sp - 2] = ba;
+        --sp;
+    }
+    goto dispatch;
+
+do_dmul:
+    if (sp >= 2) {
+        double a, b, r;
+        int64_t ba = stack[sp - 2];
+        int64_t bb = stack[sp - 1];
+        std::memcpy(&a, &ba, sizeof(double));
+        std::memcpy(&b, &bb, sizeof(double));
+        r = a * b;
+        std::memcpy(&ba, &r, sizeof(double));
+        stack[sp - 2] = ba;
+        --sp;
+    }
+    goto dispatch;
+
+do_ddiv:
+    if (sp >= 2) {
+        double a, b, r;
+        int64_t ba = stack[sp - 2];
+        int64_t bb = stack[sp - 1];
+        std::memcpy(&a, &ba, sizeof(double));
+        std::memcpy(&b, &bb, sizeof(double));
+        r = a / b;
+        std::memcpy(&ba, &r, sizeof(double));
+        stack[sp - 2] = ba;
         --sp;
     }
     goto dispatch;

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -47,7 +47,25 @@ enum OpCode : uint8_t {
     OP_AALOAD = 34, // load from object array
     OP_AASTORE = 35, // store into object array
     OP_INVOKESTATIC = 36, // invoke static java method (simplified)
-    OP_COUNT = 37  // helper constant with number of opcodes
+    OP_LLOAD = 37, // load long local
+    OP_FLOAD = 38, // load float local
+    OP_DLOAD = 39, // load double local
+    OP_LSTORE = 40, // store long local
+    OP_FSTORE = 41, // store float local
+    OP_DSTORE = 42, // store double local
+    OP_LADD = 43, // long add
+    OP_LSUB = 44, // long sub
+    OP_LMUL = 45, // long mul
+    OP_LDIV = 46, // long div
+    OP_FADD = 47, // float add
+    OP_FSUB = 48, // float sub
+    OP_FMUL = 49, // float mul
+    OP_FDIV = 50, // float div
+    OP_DADD = 51, // double add
+    OP_DSUB = 52, // double sub
+    OP_DMUL = 53, // double mul
+    OP_DDIV = 54, // double div
+    OP_COUNT = 55  // helper constant with number of opcodes
 };
 
 // Every field of an instruction is lightly encrypted and decoded at

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorNumericTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorNumericTest.java
@@ -1,0 +1,207 @@
+package by.radioegor146;
+
+import by.radioegor146.instructions.VmTranslator;
+import by.radioegor146.instructions.VmTranslator.Instruction;
+import by.radioegor146.instructions.VmTranslator.VmOpcodes;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VmTranslatorNumericTest {
+
+    static class SampleLong {
+        static long calc(long a, long b) {
+            long c = a + b;
+            long d = c * a;
+            long e = d / b;
+            return e;
+        }
+    }
+
+    static class SampleFloat {
+        static float calc(float a, float b) {
+            float c = a + b;
+            float d = c * a;
+            float e = d / b;
+            return e;
+        }
+    }
+
+    static class SampleDouble {
+        static double calc(double a, double b) {
+            double c = a + b;
+            double d = c * a;
+            double e = d / b;
+            return e;
+        }
+    }
+
+    private long run(Instruction[] code, long[] locals) {
+        long[] stack = new long[256];
+        int sp = 0;
+        for (int pc = 0; pc < code.length; pc++) {
+            Instruction ins = code[pc];
+            switch (ins.opcode) {
+                case VmOpcodes.OP_PUSH:
+                    stack[sp++] = ins.operand;
+                    break;
+                case VmOpcodes.OP_LOAD:
+                case VmOpcodes.OP_LLOAD:
+                case VmOpcodes.OP_FLOAD:
+                case VmOpcodes.OP_DLOAD:
+                    stack[sp++] = locals[ins.operand];
+                    break;
+                case VmOpcodes.OP_STORE:
+                case VmOpcodes.OP_LSTORE:
+                case VmOpcodes.OP_FSTORE:
+                case VmOpcodes.OP_DSTORE:
+                    locals[ins.operand] = stack[--sp];
+                    break;
+                case VmOpcodes.OP_ADD:
+                case VmOpcodes.OP_LADD:
+                    stack[sp - 2] += stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_SUB:
+                case VmOpcodes.OP_LSUB:
+                    stack[sp - 2] -= stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_MUL:
+                case VmOpcodes.OP_LMUL:
+                    stack[sp - 2] *= stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_DIV:
+                case VmOpcodes.OP_LDIV:
+                    long b = stack[--sp];
+                    long a = stack[sp - 1];
+                    if (b == 0) throw new ArithmeticException("/ by zero");
+                    stack[sp - 1] = a / b;
+                    break;
+                case VmOpcodes.OP_FADD: {
+                    float fb = Float.intBitsToFloat((int) stack[--sp]);
+                    float fa = Float.intBitsToFloat((int) stack[sp - 1]);
+                    stack[sp - 1] = Float.floatToIntBits(fa + fb);
+                    break;
+                }
+                case VmOpcodes.OP_FSUB: {
+                    float fb = Float.intBitsToFloat((int) stack[--sp]);
+                    float fa = Float.intBitsToFloat((int) stack[sp - 1]);
+                    stack[sp - 1] = Float.floatToIntBits(fa - fb);
+                    break;
+                }
+                case VmOpcodes.OP_FMUL: {
+                    float fb = Float.intBitsToFloat((int) stack[--sp]);
+                    float fa = Float.intBitsToFloat((int) stack[sp - 1]);
+                    stack[sp - 1] = Float.floatToIntBits(fa * fb);
+                    break;
+                }
+                case VmOpcodes.OP_FDIV: {
+                    float fb = Float.intBitsToFloat((int) stack[--sp]);
+                    float fa = Float.intBitsToFloat((int) stack[sp - 1]);
+                    stack[sp - 1] = Float.floatToIntBits(fa / fb);
+                    break;
+                }
+                case VmOpcodes.OP_DADD: {
+                    double db = Double.longBitsToDouble(stack[--sp]);
+                    double da = Double.longBitsToDouble(stack[sp - 1]);
+                    stack[sp - 1] = Double.doubleToLongBits(da + db);
+                    break;
+                }
+                case VmOpcodes.OP_DSUB: {
+                    double db = Double.longBitsToDouble(stack[--sp]);
+                    double da = Double.longBitsToDouble(stack[sp - 1]);
+                    stack[sp - 1] = Double.doubleToLongBits(da - db);
+                    break;
+                }
+                case VmOpcodes.OP_DMUL: {
+                    double db = Double.longBitsToDouble(stack[--sp]);
+                    double da = Double.longBitsToDouble(stack[sp - 1]);
+                    stack[sp - 1] = Double.doubleToLongBits(da * db);
+                    break;
+                }
+                case VmOpcodes.OP_DDIV: {
+                    double db = Double.longBitsToDouble(stack[--sp]);
+                    double da = Double.longBitsToDouble(stack[sp - 1]);
+                    stack[sp - 1] = Double.doubleToLongBits(da / db);
+                    break;
+                }
+                case VmOpcodes.OP_HALT:
+                    return sp > 0 ? stack[sp - 1] : 0;
+                default:
+                    throw new IllegalStateException("Unknown opcode: " + ins.opcode);
+            }
+        }
+        return sp > 0 ? stack[sp - 1] : 0;
+    }
+
+    @Test
+    public void testLongFloatDouble() throws Exception {
+        VmTranslator translator = new VmTranslator();
+
+        // Long operations
+        ClassReader crL = new ClassReader(SampleLong.class.getName());
+        ClassNode cnL = new ClassNode();
+        crL.accept(cnL, 0);
+        MethodNode mnL = cnL.methods.stream().filter(m -> m.name.equals("calc")).findFirst().orElseThrow();
+        Instruction[] codeL = translator.translate(mnL);
+        assertNotNull(codeL);
+        assertTrue(Arrays.stream(codeL).anyMatch(i -> i.opcode == VmOpcodes.OP_LADD));
+        assertTrue(Arrays.stream(codeL).anyMatch(i -> i.opcode == VmOpcodes.OP_LSTORE));
+        long aL = 7L, bL = 3L;
+        long[] localsL = new long[10];
+        localsL[0] = aL;
+        localsL[2] = bL;
+        long resL = run(codeL, localsL);
+        assertEquals(SampleLong.calc(aL, bL), resL);
+        assertEquals(aL + bL, localsL[4]);
+        assertEquals((aL + bL) * aL, localsL[6]);
+        assertEquals(((aL + bL) * aL) / bL, localsL[8]);
+
+        // Float operations
+        ClassReader crF = new ClassReader(SampleFloat.class.getName());
+        ClassNode cnF = new ClassNode();
+        crF.accept(cnF, 0);
+        MethodNode mnF = cnF.methods.stream().filter(m -> m.name.equals("calc")).findFirst().orElseThrow();
+        Instruction[] codeF = translator.translate(mnF);
+        assertNotNull(codeF);
+        assertTrue(Arrays.stream(codeF).anyMatch(i -> i.opcode == VmOpcodes.OP_FADD));
+        assertTrue(Arrays.stream(codeF).anyMatch(i -> i.opcode == VmOpcodes.OP_FSTORE));
+        float aF = 5.5f, bF = 2.0f;
+        long[] localsF = new long[5];
+        localsF[0] = Float.floatToIntBits(aF);
+        localsF[1] = Float.floatToIntBits(bF);
+        long resFbits = run(codeF, localsF);
+        float resF = Float.intBitsToFloat((int) resFbits);
+        assertEquals(SampleFloat.calc(aF, bF), resF, 0.0001f);
+        assertEquals(Float.floatToIntBits(aF + bF), (int) localsF[2]);
+        assertEquals(Float.floatToIntBits((aF + bF) * aF), (int) localsF[3]);
+        assertEquals(Float.floatToIntBits(((aF + bF) * aF) / bF), (int) localsF[4]);
+
+        // Double operations
+        ClassReader crD = new ClassReader(SampleDouble.class.getName());
+        ClassNode cnD = new ClassNode();
+        crD.accept(cnD, 0);
+        MethodNode mnD = cnD.methods.stream().filter(m -> m.name.equals("calc")).findFirst().orElseThrow();
+        Instruction[] codeD = translator.translate(mnD);
+        assertNotNull(codeD);
+        assertTrue(Arrays.stream(codeD).anyMatch(i -> i.opcode == VmOpcodes.OP_DADD));
+        assertTrue(Arrays.stream(codeD).anyMatch(i -> i.opcode == VmOpcodes.OP_DSTORE));
+        double aD = 7.25d, bD = 2.5d;
+        long[] localsD = new long[10];
+        localsD[0] = Double.doubleToLongBits(aD);
+        localsD[2] = Double.doubleToLongBits(bD);
+        long resDbits = run(codeD, localsD);
+        double resD = Double.longBitsToDouble(resDbits);
+        assertEquals(SampleDouble.calc(aD, bD), resD, 1e-9);
+        assertEquals(Double.doubleToLongBits(aD + bD), localsD[4]);
+        assertEquals(Double.doubleToLongBits((aD + bD) * aD), localsD[6]);
+        assertEquals(Double.doubleToLongBits(((aD + bD) * aD) / bD), localsD[8]);
+    }
+}


### PR DESCRIPTION
## Summary
- extend micro VM with load/store and arithmetic opcodes for long, float and double types
- handle new opcodes in the interpreter
- translate JVM long/float/double bytecodes into VM instructions
- add tests covering translation and execution for long, float and double operations

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c501efa8848332a5fc78645aae246d