### PR TITLE
Add VM opcodes and translation for numeric constants

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -34,9 +34,9 @@ public class VmTranslator {
     /** Representation of a VM instruction. */
     public static class Instruction {
         public final int opcode;
-        public final int operand;
+        public final long operand;
 
-        public Instruction(int opcode, int operand) {
+        public Instruction(int opcode, long operand) {
             this.opcode = opcode;
             this.operand = operand;
         }
@@ -99,6 +99,16 @@ public class VmTranslator {
         public static final int OP_DSUB = 52;
         public static final int OP_DMUL = 53;
         public static final int OP_DDIV = 54;
+        public static final int OP_LDC = 55;
+        public static final int OP_LDC_W = 56;
+        public static final int OP_LDC2_W = 57;
+        public static final int OP_FCONST_0 = 58;
+        public static final int OP_FCONST_1 = 59;
+        public static final int OP_FCONST_2 = 60;
+        public static final int OP_DCONST_0 = 61;
+        public static final int OP_DCONST_1 = 62;
+        public static final int OP_LCONST_0 = 63;
+        public static final int OP_LCONST_1 = 64;
     }
 
     /**
@@ -263,6 +273,41 @@ public class VmTranslator {
                     if (opcode == Opcodes.ICONST_M1) val = -1;
                     result.add(new Instruction(VmOpcodes.OP_PUSH, val));
                     break;
+                case Opcodes.LCONST_0:
+                    result.add(new Instruction(VmOpcodes.OP_LCONST_0, 0));
+                    break;
+                case Opcodes.LCONST_1:
+                    result.add(new Instruction(VmOpcodes.OP_LCONST_1, 0));
+                    break;
+                case Opcodes.FCONST_0:
+                    result.add(new Instruction(VmOpcodes.OP_FCONST_0, 0));
+                    break;
+                case Opcodes.FCONST_1:
+                    result.add(new Instruction(VmOpcodes.OP_FCONST_1, 0));
+                    break;
+                case Opcodes.FCONST_2:
+                    result.add(new Instruction(VmOpcodes.OP_FCONST_2, 0));
+                    break;
+                case Opcodes.DCONST_0:
+                    result.add(new Instruction(VmOpcodes.OP_DCONST_0, 0));
+                    break;
+                case Opcodes.DCONST_1:
+                    result.add(new Instruction(VmOpcodes.OP_DCONST_1, 0));
+                    break;
+                case Opcodes.LDC:
+                    Object cst = ((LdcInsnNode) insn).cst;
+                    if (cst instanceof Integer) {
+                        result.add(new Instruction(VmOpcodes.OP_LDC, (Integer) cst));
+                    } else if (cst instanceof Float) {
+                        result.add(new Instruction(VmOpcodes.OP_LDC, Float.floatToIntBits((Float) cst)));
+                    } else if (cst instanceof Long) {
+                        result.add(new Instruction(VmOpcodes.OP_LDC2_W, (Long) cst));
+                    } else if (cst instanceof Double) {
+                        result.add(new Instruction(VmOpcodes.OP_LDC2_W, Double.doubleToLongBits((Double) cst)));
+                    } else {
+                        return null; // unsupported constant
+                    }
+                    break;
                 case Opcodes.ISTORE:
                     result.add(new Instruction(VmOpcodes.OP_STORE, ((VarInsnNode) insn).var));
                     break;
@@ -368,7 +413,7 @@ public class VmTranslator {
         sb.append('{');
         for (int i = 0; i < code.length; i++) {
             Instruction ins = code[i];
-            sb.append(String.format("{ %d, %d, 0ULL }", ins.opcode, (long) ins.operand));
+            sb.append(String.format("{ %d, %d, 0ULL }", ins.opcode, ins.operand));
             if (i + 1 < code.length) sb.append(", ");
         }
         sb.append('}');

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -169,6 +169,16 @@ dispatch:
         case OP_DSUB: goto do_dsub;
         case OP_DMUL: goto do_dmul;
         case OP_DDIV: goto do_ddiv;
+        case OP_LDC:
+        case OP_LDC_W:
+        case OP_LDC2_W: goto do_push;
+        case OP_FCONST_0: goto do_fconst_0;
+        case OP_FCONST_1: goto do_fconst_1;
+        case OP_FCONST_2: goto do_fconst_2;
+        case OP_DCONST_0: goto do_dconst_0;
+        case OP_DCONST_1: goto do_dconst_1;
+        case OP_LCONST_0: goto do_lconst_0;
+        case OP_LCONST_1: goto do_lconst_1;
         case OP_INVOKESTATIC: goto do_invokestatic;
         default:       goto halt;
     }
@@ -178,6 +188,49 @@ dispatch:
 // structured control-flow patterns from static analysis.
 do_push:
     if (sp < 256) stack[sp++] = tmp;
+    goto dispatch;
+
+do_fconst_0:
+    if (sp < 256) stack[sp++] = 0;
+    goto dispatch;
+
+do_fconst_1:
+    if (sp < 256) {
+        float v = 1.0f;
+        int32_t bits;
+        std::memcpy(&bits, &v, sizeof(float));
+        stack[sp++] = static_cast<int64_t>(bits);
+    }
+    goto dispatch;
+
+do_fconst_2:
+    if (sp < 256) {
+        float v = 2.0f;
+        int32_t bits;
+        std::memcpy(&bits, &v, sizeof(float));
+        stack[sp++] = static_cast<int64_t>(bits);
+    }
+    goto dispatch;
+
+do_dconst_0:
+    if (sp < 256) stack[sp++] = 0;
+    goto dispatch;
+
+do_dconst_1:
+    if (sp < 256) {
+        double v = 1.0;
+        int64_t bits;
+        std::memcpy(&bits, &v, sizeof(double));
+        stack[sp++] = bits;
+    }
+    goto dispatch;
+
+do_lconst_0:
+    if (sp < 256) stack[sp++] = 0;
+    goto dispatch;
+
+do_lconst_1:
+    if (sp < 256) stack[sp++] = 1;
     goto dispatch;
 
 do_add:

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -65,7 +65,17 @@ enum OpCode : uint8_t {
     OP_DSUB = 52, // double sub
     OP_DMUL = 53, // double mul
     OP_DDIV = 54, // double div
-    OP_COUNT = 55  // helper constant with number of opcodes
+    OP_LDC = 55, // load constant (int/float)
+    OP_LDC_W = 56, // load wide constant (int/float)
+    OP_LDC2_W = 57, // load long/double constant
+    OP_FCONST_0 = 58, // push float 0.0
+    OP_FCONST_1 = 59, // push float 1.0
+    OP_FCONST_2 = 60, // push float 2.0
+    OP_DCONST_0 = 61, // push double 0.0
+    OP_DCONST_1 = 62, // push double 1.0
+    OP_LCONST_0 = 63, // push long 0
+    OP_LCONST_1 = 64, // push long 1
+    OP_COUNT = 65  // helper constant with number of opcodes
 };
 
 // Every field of an instruction is lightly encrypted and decoded at

--- a/obfuscator/src/test/java/by/radioegor146/VmJitBenchmarkTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmJitBenchmarkTest.java
@@ -34,7 +34,7 @@ public class VmJitBenchmarkTest {
                     stack[sp++] = ins.operand;
                     break;
                 case VmOpcodes.OP_LOAD:
-                    stack[sp++] = locals[ins.operand];
+                    stack[sp++] = locals[(int) ins.operand];
                     break;
                 case VmOpcodes.OP_ADD:
                     stack[sp - 2] += stack[sp - 1];

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorConstLoadTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorConstLoadTest.java
@@ -1,0 +1,114 @@
+package by.radioegor146;
+
+import by.radioegor146.instructions.VmTranslator;
+import by.radioegor146.instructions.VmTranslator.Instruction;
+import by.radioegor146.instructions.VmTranslator.VmOpcodes;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VmTranslatorConstLoadTest {
+
+    static class ConstSamples {
+        static int intConst() { return 123456; }
+        static long longConst() { return 1L; }
+        static long longLdc2() { return 0x1122334455667788L; }
+        static float floatConst() { return 2.0f; }
+        static float floatLdc() { return 3.5f; }
+        static double doubleConst() { return 1.0; }
+        static double doubleLdc() { return 6.5; }
+    }
+
+    private Instruction[] translate(String name) throws Exception {
+        ClassReader cr = new ClassReader(ConstSamples.class.getName());
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+        MethodNode mn = cn.methods.stream().filter(m -> m.name.equals(name)).findFirst().orElseThrow();
+        VmTranslator translator = new VmTranslator();
+        Instruction[] code = translator.translate(mn);
+        assertNotNull(code);
+        return code;
+    }
+
+    private long run(Instruction[] code) {
+        long[] stack = new long[256];
+        int sp = 0;
+        for (Instruction ins : code) {
+            switch (ins.opcode) {
+                case VmOpcodes.OP_LDC:
+                case VmOpcodes.OP_LDC_W:
+                case VmOpcodes.OP_LDC2_W:
+                case VmOpcodes.OP_PUSH:
+                    stack[sp++] = ins.operand;
+                    break;
+                case VmOpcodes.OP_FCONST_0:
+                    stack[sp++] = 0;
+                    break;
+                case VmOpcodes.OP_FCONST_1:
+                    stack[sp++] = Float.floatToIntBits(1.0f);
+                    break;
+                case VmOpcodes.OP_FCONST_2:
+                    stack[sp++] = Float.floatToIntBits(2.0f);
+                    break;
+                case VmOpcodes.OP_DCONST_0:
+                    stack[sp++] = 0;
+                    break;
+                case VmOpcodes.OP_DCONST_1:
+                    stack[sp++] = Double.doubleToLongBits(1.0);
+                    break;
+                case VmOpcodes.OP_LCONST_0:
+                    stack[sp++] = 0;
+                    break;
+                case VmOpcodes.OP_LCONST_1:
+                    stack[sp++] = 1;
+                    break;
+                case VmOpcodes.OP_HALT:
+                    return stack[sp - 1];
+            }
+        }
+        return stack[sp - 1];
+    }
+
+    @Test
+    public void testIntLdc() throws Exception {
+        Instruction[] code = translate("intConst");
+        assertEquals(VmOpcodes.OP_LDC, code[0].opcode);
+        assertEquals(123456L, run(code));
+    }
+
+    @Test
+    public void testLongConstants() throws Exception {
+        Instruction[] code1 = translate("longConst");
+        assertEquals(VmOpcodes.OP_LCONST_1, code1[0].opcode);
+        assertEquals(1L, run(code1));
+
+        Instruction[] code2 = translate("longLdc2");
+        assertEquals(VmOpcodes.OP_LDC2_W, code2[0].opcode);
+        assertEquals(0x1122334455667788L, run(code2));
+    }
+
+    @Test
+    public void testFloatConstants() throws Exception {
+        Instruction[] code1 = translate("floatConst");
+        assertEquals(VmOpcodes.OP_FCONST_2, code1[0].opcode);
+        assertEquals(Float.floatToIntBits(2.0f), (int) run(code1));
+
+        Instruction[] code2 = translate("floatLdc");
+        assertEquals(VmOpcodes.OP_LDC, code2[0].opcode);
+        assertEquals(Float.floatToIntBits(3.5f), (int) run(code2));
+    }
+
+    @Test
+    public void testDoubleConstants() throws Exception {
+        Instruction[] code1 = translate("doubleConst");
+        assertEquals(VmOpcodes.OP_DCONST_1, code1[0].opcode);
+        assertEquals(Double.doubleToLongBits(1.0), run(code1));
+
+        Instruction[] code2 = translate("doubleLdc");
+        assertEquals(VmOpcodes.OP_LDC2_W, code2[0].opcode);
+        assertEquals(Double.doubleToLongBits(6.5), run(code2));
+    }
+}

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorExecutionTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorExecutionTest.java
@@ -40,10 +40,10 @@ public class VmTranslatorExecutionTest {
                     stack[sp++] = ins.operand;
                     break;
                 case VmOpcodes.OP_LOAD:
-                    stack[sp++] = locals[ins.operand];
+                    stack[sp++] = locals[(int) ins.operand];
                     break;
                 case VmOpcodes.OP_STORE:
-                    locals[ins.operand] = stack[--sp];
+                    locals[(int) ins.operand] = stack[--sp];
                     break;
                 case VmOpcodes.OP_ADD:
                     stack[sp - 2] += stack[sp - 1];

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorNumericTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorNumericTest.java
@@ -54,13 +54,13 @@ public class VmTranslatorNumericTest {
                 case VmOpcodes.OP_LLOAD:
                 case VmOpcodes.OP_FLOAD:
                 case VmOpcodes.OP_DLOAD:
-                    stack[sp++] = locals[ins.operand];
+                    stack[sp++] = locals[(int) ins.operand];
                     break;
                 case VmOpcodes.OP_STORE:
                 case VmOpcodes.OP_LSTORE:
                 case VmOpcodes.OP_FSTORE:
                 case VmOpcodes.OP_DSTORE:
-                    locals[ins.operand] = stack[--sp];
+                    locals[(int) ins.operand] = stack[--sp];
                     break;
                 case VmOpcodes.OP_ADD:
                 case VmOpcodes.OP_LADD:

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorObjectTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorObjectTest.java
@@ -34,13 +34,16 @@ public class VmTranslatorObjectTest {
             Instruction ins = code[pc++];
             switch (ins.opcode) {
                 case VmOpcodes.OP_PUSH:
-                    stack[sp++] = (long) ins.operand;
+                case VmOpcodes.OP_LDC:
+                case VmOpcodes.OP_LDC_W:
+                case VmOpcodes.OP_LDC2_W:
+                    stack[sp++] = ins.operand;
                     break;
                 case VmOpcodes.OP_ALOAD:
-                    stack[sp++] = locals[ins.operand];
+                    stack[sp++] = locals[(int) ins.operand];
                     break;
                 case VmOpcodes.OP_ASTORE:
-                    locals[ins.operand] = stack[--sp];
+                    locals[(int) ins.operand] = stack[--sp];
                     break;
                 case VmOpcodes.OP_AALOAD:
                     int idx = (int) (long) stack[--sp];
@@ -54,7 +57,7 @@ public class VmTranslatorObjectTest {
                     arr2[idx2] = val;
                     break;
                 case VmOpcodes.OP_INVOKESTATIC:
-                    Method m = methods.get(ins.operand);
+                    Method m = methods.get((int) ins.operand);
                     Object arg = stack[--sp];
                     Object res = m.invoke(null, arg);
                     stack[sp++] = res;


### PR DESCRIPTION
## Summary
- support LDC/LDC_W/LDC2_W, FCONST_*, DCONST_*, LCONST_* opcodes in micro VM
- widen VM instruction operand to 64-bit and emit new opcodes from VmTranslator
- add tests for loading numeric constants across int, long, float, and double types

## Testing
- `./gradlew :obfuscator:test --tests "by.radioegor146.VmTranslator*"`


------
https://chatgpt.com/codex/tasks/task_e_68c50470959c8332ae4b10125bc13531