### PR TITLE
Add IINC and long bitwise operations to VM

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -109,6 +109,13 @@ public class VmTranslator {
         public static final int OP_DCONST_1 = 62;
         public static final int OP_LCONST_0 = 63;
         public static final int OP_LCONST_1 = 64;
+        public static final int OP_IINC = 65;
+        public static final int OP_LAND = 66;
+        public static final int OP_LOR = 67;
+        public static final int OP_LXOR = 68;
+        public static final int OP_LSHL = 69;
+        public static final int OP_LSHR = 70;
+        public static final int OP_LUSHR = 71;
     }
 
     /**
@@ -234,6 +241,24 @@ public class VmTranslator {
                 case Opcodes.IUSHR:
                     result.add(new Instruction(VmOpcodes.OP_USHR, 0));
                     break;
+                case Opcodes.LAND:
+                    result.add(new Instruction(VmOpcodes.OP_LAND, 0));
+                    break;
+                case Opcodes.LOR:
+                    result.add(new Instruction(VmOpcodes.OP_LOR, 0));
+                    break;
+                case Opcodes.LXOR:
+                    result.add(new Instruction(VmOpcodes.OP_LXOR, 0));
+                    break;
+                case Opcodes.LSHL:
+                    result.add(new Instruction(VmOpcodes.OP_LSHL, 0));
+                    break;
+                case Opcodes.LSHR:
+                    result.add(new Instruction(VmOpcodes.OP_LSHR, 0));
+                    break;
+                case Opcodes.LUSHR:
+                    result.add(new Instruction(VmOpcodes.OP_LUSHR, 0));
+                    break;
                 case Opcodes.ALOAD:
                     result.add(new Instruction(VmOpcodes.OP_ALOAD, ((VarInsnNode) insn).var));
                     break;
@@ -344,6 +369,12 @@ public class VmTranslator {
                 case 74: // DSTORE_3
                     result.add(new Instruction(VmOpcodes.OP_DSTORE, opcode - 71));
                     break;
+                case Opcodes.IINC: {
+                    IincInsnNode ii = (IincInsnNode) insn;
+                    long operand = ((long) ii.incr << 32) | (ii.var & 0xFFFFFFFFL);
+                    result.add(new Instruction(VmOpcodes.OP_IINC, operand));
+                    break;
+                }
                 case Opcodes.GOTO:
                     result.add(new Instruction(VmOpcodes.OP_GOTO, labelIds.get(((JumpInsnNode) insn).label)));
                     break;

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -179,6 +179,13 @@ dispatch:
         case OP_DCONST_1: goto do_dconst_1;
         case OP_LCONST_0: goto do_lconst_0;
         case OP_LCONST_1: goto do_lconst_1;
+        case OP_IINC: goto do_iinc;
+        case OP_LAND: goto do_and;
+        case OP_LOR: goto do_or;
+        case OP_LXOR: goto do_xor;
+        case OP_LSHL: goto do_shl;
+        case OP_LSHR: goto do_shr;
+        case OP_LUSHR: goto do_ushr;
         case OP_INVOKESTATIC: goto do_invokestatic;
         default:       goto halt;
     }
@@ -402,6 +409,18 @@ do_store:
     if (sp >= 1 && tmp >= 0 && static_cast<size_t>(tmp) < locals_length && locals != nullptr) {
         locals[tmp] = stack[sp - 1];
         --sp;
+    }
+    goto dispatch;
+
+do_iinc:
+    if (locals != nullptr) {
+        uint32_t idx = static_cast<uint32_t>(tmp & 0xFFFFFFFFULL);
+        int32_t inc = static_cast<int32_t>(tmp >> 32);
+        if (idx < locals_length) {
+            int32_t val = static_cast<int32_t>(locals[idx]);
+            val += inc;
+            locals[idx] = static_cast<int64_t>(val);
+        }
     }
     goto dispatch;
 

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -75,7 +75,14 @@ enum OpCode : uint8_t {
     OP_DCONST_1 = 62, // push double 1.0
     OP_LCONST_0 = 63, // push long 0
     OP_LCONST_1 = 64, // push long 1
-    OP_COUNT = 65  // helper constant with number of opcodes
+    OP_IINC = 65,  // increment int local by constant
+    OP_LAND = 66,  // long bitwise and
+    OP_LOR  = 67,  // long bitwise or
+    OP_LXOR = 68,  // long bitwise xor
+    OP_LSHL = 69,  // long shift left
+    OP_LSHR = 70,  // long arithmetic shift right
+    OP_LUSHR = 71, // long logical shift right
+    OP_COUNT = 72  // helper constant with number of opcodes
 };
 
 // Every field of an instruction is lightly encrypted and decoded at

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorBitwiseTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorBitwiseTest.java
@@ -1,0 +1,183 @@
+package by.radioegor146;
+
+import by.radioegor146.instructions.VmTranslator;
+import by.radioegor146.instructions.VmTranslator.Instruction;
+import by.radioegor146.instructions.VmTranslator.VmOpcodes;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VmTranslatorBitwiseTest {
+
+    static class SampleInc {
+        static int calc(int a) {
+            a++;
+            a--;
+            return a;
+        }
+    }
+
+    static class SampleLongBitwise {
+        static long calc(long a, long b) {
+            long c = a & b;
+            long d = a | b;
+            long e = a ^ b;
+            return c + d + e;
+        }
+    }
+
+    static class SampleShift {
+        static long calc(int i, long l) {
+            int a = i << 1;
+            int b = i >> 2;
+            int c = i >>> 3;
+            long d = l << 1;
+            long e = l >> 2;
+            long f = l >>> 3;
+            return a + b + c + d + e + f;
+        }
+    }
+
+    private long run(Instruction[] code, long[] locals) {
+        long[] stack = new long[256];
+        int sp = 0;
+        for (int pc = 0; pc < code.length; pc++) {
+            Instruction ins = code[pc];
+            switch (ins.opcode) {
+                case VmOpcodes.OP_PUSH:
+                    stack[sp++] = ins.operand;
+                    break;
+                case VmOpcodes.OP_LOAD:
+                case VmOpcodes.OP_LLOAD:
+                case VmOpcodes.OP_FLOAD:
+                case VmOpcodes.OP_DLOAD:
+                    stack[sp++] = locals[(int) ins.operand];
+                    break;
+                case VmOpcodes.OP_STORE:
+                case VmOpcodes.OP_LSTORE:
+                case VmOpcodes.OP_FSTORE:
+                case VmOpcodes.OP_DSTORE:
+                    locals[(int) ins.operand] = stack[--sp];
+                    break;
+                case VmOpcodes.OP_IINC: {
+                    int idx = (int) (ins.operand & 0xFFFFFFFFL);
+                    int inc = (int) (ins.operand >> 32);
+                    int val = (int) locals[idx];
+                    val += inc;
+                    locals[idx] = val;
+                    break;
+                }
+                case VmOpcodes.OP_ADD:
+                case VmOpcodes.OP_LADD:
+                    stack[sp - 2] += stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_SUB:
+                case VmOpcodes.OP_LSUB:
+                    stack[sp - 2] -= stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_AND:
+                case VmOpcodes.OP_LAND:
+                    stack[sp - 2] &= stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_OR:
+                case VmOpcodes.OP_LOR:
+                    stack[sp - 2] |= stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_XOR:
+                case VmOpcodes.OP_LXOR:
+                    stack[sp - 2] ^= stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_SHL:
+                case VmOpcodes.OP_LSHL:
+                    stack[sp - 2] <<= stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_SHR:
+                case VmOpcodes.OP_LSHR:
+                    stack[sp - 2] >>= stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_USHR:
+                case VmOpcodes.OP_LUSHR:
+                    stack[sp - 2] = (long) (((long) stack[sp - 2]) >>> stack[sp - 1]);
+                    sp--;
+                    break;
+                case VmOpcodes.OP_I2L:
+                    stack[sp - 1] = (long) (int) stack[sp - 1];
+                    break;
+                case VmOpcodes.OP_HALT:
+                    return sp > 0 ? stack[sp - 1] : 0;
+                default:
+                    throw new IllegalStateException("Unknown opcode: " + ins.opcode);
+            }
+        }
+        return sp > 0 ? stack[sp - 1] : 0;
+    }
+
+    @Test
+    public void testIInc() throws Exception {
+        VmTranslator translator = new VmTranslator();
+        ClassReader cr = new ClassReader(SampleInc.class.getName());
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+        MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("calc")).findFirst().orElseThrow();
+        Instruction[] code = translator.translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_IINC));
+        long[] locals = new long[1];
+        locals[0] = 5;
+        long res = run(code, locals);
+        assertEquals(SampleInc.calc(5), (int) res);
+    }
+
+    @Test
+    public void testLongBitwise() throws Exception {
+        VmTranslator translator = new VmTranslator();
+        ClassReader cr = new ClassReader(SampleLongBitwise.class.getName());
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+        MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("calc")).findFirst().orElseThrow();
+        Instruction[] code = translator.translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_LAND));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_LOR));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_LXOR));
+        long[] locals = new long[10];
+        locals[0] = 0x0F0FL;
+        locals[2] = 0x00FFL;
+        long res = run(code, locals);
+        assertEquals(SampleLongBitwise.calc(0x0F0FL, 0x00FFL), res);
+    }
+
+    @Test
+    public void testShifts() throws Exception {
+        VmTranslator translator = new VmTranslator();
+        ClassReader cr = new ClassReader(SampleShift.class.getName());
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+        MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("calc")).findFirst().orElseThrow();
+        Instruction[] code = translator.translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_SHL));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_SHR));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_USHR));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_LSHL));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_LSHR));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_LUSHR));
+        long[] locals = new long[12];
+        locals[0] = 6; // i
+        locals[1] = 13L; // l
+        long res = run(code, locals);
+        assertEquals(SampleShift.calc(6, 13L), res);
+    }
+}


### PR DESCRIPTION
## Summary
- support IINC and long bitwise/shift ops in micro VM
- translate IINC and long bitwise instructions in `VmTranslator`
- cover iinc, long bitwise, and shift behaviors with new tests

## Testing
- `./gradlew :obfuscator:test --tests "by.radioegor146.VmTranslatorBitwiseTest.testIInc"`
- `./gradlew :obfuscator:test --tests "by.radioegor146.VmTranslatorBitwiseTest.testLongBitwise"`
- `./gradlew :obfuscator:test --tests "by.radioegor146.VmTranslatorBitwiseTest.testShifts"`


------
https://chatgpt.com/codex/tasks/task_e_68c50d1a77708332a787bdc9db73eafc