### PR TITLE
Support numeric primitive conversions in micro VM

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -116,6 +116,17 @@ public class VmTranslator {
         public static final int OP_LSHL = 69;
         public static final int OP_LSHR = 70;
         public static final int OP_LUSHR = 71;
+        public static final int OP_I2F = 72;
+        public static final int OP_I2D = 73;
+        public static final int OP_L2I = 74;
+        public static final int OP_L2F = 75;
+        public static final int OP_L2D = 76;
+        public static final int OP_F2I = 77;
+        public static final int OP_F2L = 78;
+        public static final int OP_F2D = 79;
+        public static final int OP_D2I = 80;
+        public static final int OP_D2L = 81;
+        public static final int OP_D2F = 82;
     }
 
     /**
@@ -416,6 +427,39 @@ public class VmTranslator {
                     break;
                 case Opcodes.I2L:
                     result.add(new Instruction(VmOpcodes.OP_I2L, 0));
+                    break;
+                case Opcodes.I2F:
+                    result.add(new Instruction(VmOpcodes.OP_I2F, 0));
+                    break;
+                case Opcodes.I2D:
+                    result.add(new Instruction(VmOpcodes.OP_I2D, 0));
+                    break;
+                case Opcodes.L2I:
+                    result.add(new Instruction(VmOpcodes.OP_L2I, 0));
+                    break;
+                case Opcodes.L2F:
+                    result.add(new Instruction(VmOpcodes.OP_L2F, 0));
+                    break;
+                case Opcodes.L2D:
+                    result.add(new Instruction(VmOpcodes.OP_L2D, 0));
+                    break;
+                case Opcodes.F2I:
+                    result.add(new Instruction(VmOpcodes.OP_F2I, 0));
+                    break;
+                case Opcodes.F2L:
+                    result.add(new Instruction(VmOpcodes.OP_F2L, 0));
+                    break;
+                case Opcodes.F2D:
+                    result.add(new Instruction(VmOpcodes.OP_F2D, 0));
+                    break;
+                case Opcodes.D2I:
+                    result.add(new Instruction(VmOpcodes.OP_D2I, 0));
+                    break;
+                case Opcodes.D2L:
+                    result.add(new Instruction(VmOpcodes.OP_D2L, 0));
+                    break;
+                case Opcodes.D2F:
+                    result.add(new Instruction(VmOpcodes.OP_D2F, 0));
                     break;
                 case Opcodes.INEG:
                     result.add(new Instruction(VmOpcodes.OP_NEG, 0));

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -152,6 +152,17 @@ dispatch:
         case OP_I2B: goto do_i2b;
         case OP_I2C: goto do_i2c;
         case OP_I2S: goto do_i2s;
+        case OP_I2F: goto do_i2f;
+        case OP_I2D: goto do_i2d;
+        case OP_L2I: goto do_l2i;
+        case OP_L2F: goto do_l2f;
+        case OP_L2D: goto do_l2d;
+        case OP_F2I: goto do_f2i;
+        case OP_F2L: goto do_f2l;
+        case OP_F2D: goto do_f2d;
+        case OP_D2I: goto do_d2i;
+        case OP_D2L: goto do_d2l;
+        case OP_D2F: goto do_d2f;
         case OP_NEG: goto do_neg;
         case OP_ALOAD: goto do_aload;
         case OP_ASTORE: goto do_astore;
@@ -520,6 +531,103 @@ do_i2c:
 
 do_i2s:
     if (sp >= 1) stack[sp - 1] = static_cast<int64_t>(static_cast<int16_t>(stack[sp - 1]));
+    goto dispatch;
+
+do_i2f:
+    if (sp >= 1) {
+        float f = static_cast<float>(static_cast<int32_t>(stack[sp - 1]));
+        int32_t bits;
+        std::memcpy(&bits, &f, sizeof(float));
+        stack[sp - 1] = static_cast<int64_t>(bits);
+    }
+    goto dispatch;
+
+do_i2d:
+    if (sp >= 1) {
+        double d = static_cast<double>(static_cast<int32_t>(stack[sp - 1]));
+        int64_t bits;
+        std::memcpy(&bits, &d, sizeof(double));
+        stack[sp - 1] = bits;
+    }
+    goto dispatch;
+
+do_l2i:
+    if (sp >= 1) stack[sp - 1] = static_cast<int64_t>(static_cast<int32_t>(stack[sp - 1]));
+    goto dispatch;
+
+do_l2f:
+    if (sp >= 1) {
+        float f = static_cast<float>(stack[sp - 1]);
+        int32_t bits;
+        std::memcpy(&bits, &f, sizeof(float));
+        stack[sp - 1] = static_cast<int64_t>(bits);
+    }
+    goto dispatch;
+
+do_l2d:
+    if (sp >= 1) {
+        double d = static_cast<double>(stack[sp - 1]);
+        int64_t bits;
+        std::memcpy(&bits, &d, sizeof(double));
+        stack[sp - 1] = bits;
+    }
+    goto dispatch;
+
+do_f2i:
+    if (sp >= 1) {
+        float f;
+        int32_t bits = static_cast<int32_t>(stack[sp - 1]);
+        std::memcpy(&f, &bits, sizeof(float));
+        stack[sp - 1] = static_cast<int64_t>(static_cast<int32_t>(f));
+    }
+    goto dispatch;
+
+do_f2l:
+    if (sp >= 1) {
+        float f;
+        int32_t bits = static_cast<int32_t>(stack[sp - 1]);
+        std::memcpy(&f, &bits, sizeof(float));
+        stack[sp - 1] = static_cast<int64_t>(static_cast<int64_t>(f));
+    }
+    goto dispatch;
+
+do_f2d:
+    if (sp >= 1) {
+        float f;
+        int32_t bits = static_cast<int32_t>(stack[sp - 1]);
+        std::memcpy(&f, &bits, sizeof(float));
+        double d = static_cast<double>(f);
+        int64_t dbits;
+        std::memcpy(&dbits, &d, sizeof(double));
+        stack[sp - 1] = dbits;
+    }
+    goto dispatch;
+
+do_d2i:
+    if (sp >= 1) {
+        double d;
+        std::memcpy(&d, &stack[sp - 1], sizeof(double));
+        stack[sp - 1] = static_cast<int64_t>(static_cast<int32_t>(d));
+    }
+    goto dispatch;
+
+do_d2l:
+    if (sp >= 1) {
+        double d;
+        std::memcpy(&d, &stack[sp - 1], sizeof(double));
+        stack[sp - 1] = static_cast<int64_t>(static_cast<int64_t>(d));
+    }
+    goto dispatch;
+
+do_d2f:
+    if (sp >= 1) {
+        double d;
+        std::memcpy(&d, &stack[sp - 1], sizeof(double));
+        float f = static_cast<float>(d);
+        int32_t fbits;
+        std::memcpy(&fbits, &f, sizeof(float));
+        stack[sp - 1] = static_cast<int64_t>(fbits);
+    }
     goto dispatch;
 
 do_neg:

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -82,7 +82,18 @@ enum OpCode : uint8_t {
     OP_LSHL = 69,  // long shift left
     OP_LSHR = 70,  // long arithmetic shift right
     OP_LUSHR = 71, // long logical shift right
-    OP_COUNT = 72  // helper constant with number of opcodes
+    OP_I2F = 72,   // convert int to float
+    OP_I2D = 73,   // convert int to double
+    OP_L2I = 74,   // convert long to int
+    OP_L2F = 75,   // convert long to float
+    OP_L2D = 76,   // convert long to double
+    OP_F2I = 77,   // convert float to int
+    OP_F2L = 78,   // convert float to long
+    OP_F2D = 79,   // convert float to double
+    OP_D2I = 80,   // convert double to int
+    OP_D2L = 81,   // convert double to long
+    OP_D2F = 82,   // convert double to float
+    OP_COUNT = 83  // helper constant with number of opcodes
 };
 
 // Every field of an instruction is lightly encrypted and decoded at

--- a/obfuscator/src/main/resources/sources/vm_jit.cpp
+++ b/obfuscator/src/main/resources/sources/vm_jit.cpp
@@ -133,6 +133,78 @@ static int64_t run_program(JNIEnv* env, int64_t* locals, size_t locals_len,
             case OP_I2S:
                 if (sp >= 1) stack[sp-1] = (int16_t)stack[sp-1];
                 break;
+            case OP_I2F:
+                if (sp >= 1) {
+                    float f = (float)(int32_t)stack[sp-1];
+                    int32_t bits; std::memcpy(&bits, &f, sizeof(float));
+                    stack[sp-1] = bits;
+                }
+                break;
+            case OP_I2D:
+                if (sp >= 1) {
+                    double d = (double)(int32_t)stack[sp-1];
+                    int64_t bits; std::memcpy(&bits, &d, sizeof(double));
+                    stack[sp-1] = bits;
+                }
+                break;
+            case OP_L2I:
+                if (sp >= 1) stack[sp-1] = (int32_t)stack[sp-1];
+                break;
+            case OP_L2F:
+                if (sp >= 1) {
+                    float f = (float)stack[sp-1];
+                    int32_t bits; std::memcpy(&bits, &f, sizeof(float));
+                    stack[sp-1] = bits;
+                }
+                break;
+            case OP_L2D:
+                if (sp >= 1) {
+                    double d = (double)stack[sp-1];
+                    int64_t bits; std::memcpy(&bits, &d, sizeof(double));
+                    stack[sp-1] = bits;
+                }
+                break;
+            case OP_F2I:
+                if (sp >= 1) {
+                    float f; int32_t bits = (int32_t)stack[sp-1];
+                    std::memcpy(&f, &bits, sizeof(float));
+                    stack[sp-1] = (int32_t)f;
+                }
+                break;
+            case OP_F2L:
+                if (sp >= 1) {
+                    float f; int32_t bits = (int32_t)stack[sp-1];
+                    std::memcpy(&f, &bits, sizeof(float));
+                    stack[sp-1] = (int64_t)f;
+                }
+                break;
+            case OP_F2D:
+                if (sp >= 1) {
+                    float f; int32_t bits = (int32_t)stack[sp-1];
+                    std::memcpy(&f, &bits, sizeof(float));
+                    double d = (double)f; int64_t dbits; std::memcpy(&dbits, &d, sizeof(double));
+                    stack[sp-1] = dbits;
+                }
+                break;
+            case OP_D2I:
+                if (sp >= 1) {
+                    double d; std::memcpy(&d, &stack[sp-1], sizeof(double));
+                    stack[sp-1] = (int32_t)d;
+                }
+                break;
+            case OP_D2L:
+                if (sp >= 1) {
+                    double d; std::memcpy(&d, &stack[sp-1], sizeof(double));
+                    stack[sp-1] = (int64_t)d;
+                }
+                break;
+            case OP_D2F:
+                if (sp >= 1) {
+                    double d; std::memcpy(&d, &stack[sp-1], sizeof(double));
+                    float f = (float)d; int32_t fbits; std::memcpy(&fbits, &f, sizeof(float));
+                    stack[sp-1] = fbits;
+                }
+                break;
             case OP_NEG:
                 if (sp >= 1) stack[sp-1] = -stack[sp-1];
                 break;

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorConversionTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorConversionTest.java
@@ -1,0 +1,228 @@
+package by.radioegor146;
+
+import by.radioegor146.instructions.VmTranslator;
+import by.radioegor146.instructions.VmTranslator.Instruction;
+import by.radioegor146.instructions.VmTranslator.VmOpcodes;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VmTranslatorConversionTest {
+
+    static class Sample {
+        static float i2f(int a) { return (float) a; }
+        static double i2d(int a) { return (double) a; }
+        static int l2i(long a) { return (int) a; }
+        static float l2f(long a) { return (float) a; }
+        static double l2d(long a) { return (double) a; }
+        static int f2i(float a) { return (int) a; }
+        static long f2l(float a) { return (long) a; }
+        static double f2d(float a) { return (double) a; }
+        static int d2i(double a) { return (int) a; }
+        static long d2l(double a) { return (long) a; }
+        static float d2f(double a) { return (float) a; }
+    }
+
+    private long run(Instruction[] code, long[] locals) {
+        long[] stack = new long[256];
+        int sp = 0;
+        for (Instruction ins : code) {
+            switch (ins.opcode) {
+                case VmOpcodes.OP_PUSH:
+                    stack[sp++] = ins.operand;
+                    break;
+                case VmOpcodes.OP_LOAD:
+                case VmOpcodes.OP_LLOAD:
+                case VmOpcodes.OP_FLOAD:
+                case VmOpcodes.OP_DLOAD:
+                    stack[sp++] = locals[(int) ins.operand];
+                    break;
+                case VmOpcodes.OP_I2F:
+                    stack[sp - 1] = Float.floatToIntBits((float) (int) stack[sp - 1]);
+                    break;
+                case VmOpcodes.OP_I2D:
+                    stack[sp - 1] = Double.doubleToLongBits((double) (int) stack[sp - 1]);
+                    break;
+                case VmOpcodes.OP_L2I:
+                    stack[sp - 1] = (int) stack[sp - 1];
+                    break;
+                case VmOpcodes.OP_L2F:
+                    stack[sp - 1] = Float.floatToIntBits((float) stack[sp - 1]);
+                    break;
+                case VmOpcodes.OP_L2D:
+                    stack[sp - 1] = Double.doubleToLongBits((double) stack[sp - 1]);
+                    break;
+                case VmOpcodes.OP_F2I: {
+                    float f = Float.intBitsToFloat((int) stack[sp - 1]);
+                    stack[sp - 1] = (int) f;
+                    break;
+                }
+                case VmOpcodes.OP_F2L: {
+                    float f = Float.intBitsToFloat((int) stack[sp - 1]);
+                    stack[sp - 1] = (long) f;
+                    break;
+                }
+                case VmOpcodes.OP_F2D: {
+                    float f = Float.intBitsToFloat((int) stack[sp - 1]);
+                    stack[sp - 1] = Double.doubleToLongBits((double) f);
+                    break;
+                }
+                case VmOpcodes.OP_D2I: {
+                    double d = Double.longBitsToDouble(stack[sp - 1]);
+                    stack[sp - 1] = (int) d;
+                    break;
+                }
+                case VmOpcodes.OP_D2L: {
+                    double d = Double.longBitsToDouble(stack[sp - 1]);
+                    stack[sp - 1] = (long) d;
+                    break;
+                }
+                case VmOpcodes.OP_D2F: {
+                    double d = Double.longBitsToDouble(stack[sp - 1]);
+                    stack[sp - 1] = Float.floatToIntBits((float) d);
+                    break;
+                }
+                case VmOpcodes.OP_HALT:
+                    return sp > 0 ? stack[sp - 1] : 0;
+                default:
+                    throw new IllegalStateException("Unknown opcode: " + ins.opcode);
+            }
+        }
+        return sp > 0 ? stack[sp - 1] : 0;
+    }
+
+    @Test
+    public void testConversions() throws Exception {
+        VmTranslator translator = new VmTranslator();
+        ClassReader cr = new ClassReader(Sample.class.getName());
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+
+        // I2F
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("i2f")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_I2F));
+            long[] locals = new long[1];
+            locals[0] = 42;
+            long res = run(code, locals);
+            assertEquals(Float.floatToIntBits(Sample.i2f(42)), (int) res);
+        }
+        // I2D
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("i2d")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_I2D));
+            long[] locals = new long[1];
+            locals[0] = 5;
+            long res = run(code, locals);
+            assertEquals(Double.doubleToLongBits(Sample.i2d(5)), res);
+        }
+        // L2I
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("l2i")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_L2I));
+            long[] locals = new long[2];
+            locals[0] = 1234567890123L;
+            long res = run(code, locals);
+            assertEquals(Sample.l2i(1234567890123L), res);
+        }
+        // L2F
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("l2f")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_L2F));
+            long[] locals = new long[2];
+            locals[0] = 1000L;
+            long res = run(code, locals);
+            assertEquals(Float.floatToIntBits(Sample.l2f(1000L)), (int) res);
+        }
+        // L2D
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("l2d")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_L2D));
+            long[] locals = new long[2];
+            locals[0] = 1000L;
+            long res = run(code, locals);
+            assertEquals(Double.doubleToLongBits(Sample.l2d(1000L)), res);
+        }
+        // F2I
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("f2i")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_F2I));
+            long[] locals = new long[1];
+            locals[0] = Float.floatToIntBits(3.5f);
+            long res = run(code, locals);
+            assertEquals(Sample.f2i(3.5f), res);
+        }
+        // F2L
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("f2l")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_F2L));
+            long[] locals = new long[1];
+            locals[0] = Float.floatToIntBits(2.75f);
+            long res = run(code, locals);
+            assertEquals(Sample.f2l(2.75f), res);
+        }
+        // F2D
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("f2d")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_F2D));
+            long[] locals = new long[1];
+            locals[0] = Float.floatToIntBits(1.25f);
+            long res = run(code, locals);
+            assertEquals(Double.doubleToLongBits(Sample.f2d(1.25f)), res);
+        }
+        // D2I
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("d2i")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_D2I));
+            long[] locals = new long[2];
+            locals[0] = Double.doubleToLongBits(8.5d);
+            long res = run(code, locals);
+            assertEquals(Sample.d2i(8.5d), res);
+        }
+        // D2L
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("d2l")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_D2L));
+            long[] locals = new long[2];
+            locals[0] = Double.doubleToLongBits(8.5d);
+            long res = run(code, locals);
+            assertEquals(Sample.d2l(8.5d), res);
+        }
+        // D2F
+        {
+            MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("d2f")).findFirst().orElseThrow();
+            Instruction[] code = translator.translate(mn);
+            assertNotNull(code);
+            assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_D2F));
+            long[] locals = new long[2];
+            locals[0] = Double.doubleToLongBits(6.25d);
+            long res = run(code, locals);
+            assertEquals(Float.floatToIntBits(Sample.d2f(6.25d)), (int) res);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add int/long/float/double conversion opcodes to the micro VM and JIT
- map JVM conversion bytecodes in VmTranslator
- test all conversion paths

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c5158fa7948332a2b81ba3a9193df8