### PR TITLE
Add primitive array load/store opcodes

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -127,6 +127,14 @@ public class VmTranslator {
         public static final int OP_D2I = 80;
         public static final int OP_D2L = 81;
         public static final int OP_D2F = 82;
+        public static final int OP_IALOAD = 83;
+        public static final int OP_BALOAD = 84;
+        public static final int OP_CALOAD = 85;
+        public static final int OP_SALOAD = 86;
+        public static final int OP_IASTORE = 87;
+        public static final int OP_BASTORE = 88;
+        public static final int OP_CASTORE = 89;
+        public static final int OP_SASTORE = 90;
     }
 
     /**
@@ -293,6 +301,30 @@ public class VmTranslator {
                     break;
                 case Opcodes.AASTORE:
                     result.add(new Instruction(VmOpcodes.OP_AASTORE, 0));
+                    break;
+                case Opcodes.IALOAD:
+                    result.add(new Instruction(VmOpcodes.OP_IALOAD, 0));
+                    break;
+                case Opcodes.BALOAD:
+                    result.add(new Instruction(VmOpcodes.OP_BALOAD, 0));
+                    break;
+                case Opcodes.CALOAD:
+                    result.add(new Instruction(VmOpcodes.OP_CALOAD, 0));
+                    break;
+                case Opcodes.SALOAD:
+                    result.add(new Instruction(VmOpcodes.OP_SALOAD, 0));
+                    break;
+                case Opcodes.IASTORE:
+                    result.add(new Instruction(VmOpcodes.OP_IASTORE, 0));
+                    break;
+                case Opcodes.BASTORE:
+                    result.add(new Instruction(VmOpcodes.OP_BASTORE, 0));
+                    break;
+                case Opcodes.CASTORE:
+                    result.add(new Instruction(VmOpcodes.OP_CASTORE, 0));
+                    break;
+                case Opcodes.SASTORE:
+                    result.add(new Instruction(VmOpcodes.OP_SASTORE, 0));
                     break;
                 case Opcodes.BIPUSH:
                 case Opcodes.SIPUSH:

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -168,6 +168,14 @@ dispatch:
         case OP_ASTORE: goto do_astore;
         case OP_AALOAD: goto do_aaload;
         case OP_AASTORE: goto do_aastore;
+        case OP_IALOAD: goto do_iaload;
+        case OP_BALOAD: goto do_baload;
+        case OP_CALOAD: goto do_caload;
+        case OP_SALOAD: goto do_saload;
+        case OP_IASTORE: goto do_iastore;
+        case OP_BASTORE: goto do_bastore;
+        case OP_CASTORE: goto do_castore;
+        case OP_SASTORE: goto do_sastore;
         case OP_LADD: goto do_add;
         case OP_LSUB: goto do_sub;
         case OP_LMUL: goto do_mul;
@@ -662,6 +670,82 @@ do_aastore:
         jsize index = static_cast<jsize>(stack[--sp]);
         jobjectArray arr = reinterpret_cast<jobjectArray>(stack[--sp]);
         env->SetObjectArrayElement(arr, index, value);
+    }
+    goto dispatch;
+
+do_iaload:
+    if (sp >= 2) {
+        jsize index = static_cast<jsize>(stack[--sp]);
+        jintArray arr = reinterpret_cast<jintArray>(stack[--sp]);
+        jint val;
+        env->GetIntArrayRegion(arr, index, 1, &val);
+        stack[sp++] = val;
+    }
+    goto dispatch;
+
+do_baload:
+    if (sp >= 2) {
+        jsize index = static_cast<jsize>(stack[--sp]);
+        jbyteArray arr = reinterpret_cast<jbyteArray>(stack[--sp]);
+        jbyte val;
+        env->GetByteArrayRegion(arr, index, 1, &val);
+        stack[sp++] = val;
+    }
+    goto dispatch;
+
+do_caload:
+    if (sp >= 2) {
+        jsize index = static_cast<jsize>(stack[--sp]);
+        jcharArray arr = reinterpret_cast<jcharArray>(stack[--sp]);
+        jchar val;
+        env->GetCharArrayRegion(arr, index, 1, &val);
+        stack[sp++] = val;
+    }
+    goto dispatch;
+
+do_saload:
+    if (sp >= 2) {
+        jsize index = static_cast<jsize>(stack[--sp]);
+        jshortArray arr = reinterpret_cast<jshortArray>(stack[--sp]);
+        jshort val;
+        env->GetShortArrayRegion(arr, index, 1, &val);
+        stack[sp++] = val;
+    }
+    goto dispatch;
+
+do_iastore:
+    if (sp >= 3) {
+        jint value = static_cast<jint>(stack[--sp]);
+        jsize index = static_cast<jsize>(stack[--sp]);
+        jintArray arr = reinterpret_cast<jintArray>(stack[--sp]);
+        env->SetIntArrayRegion(arr, index, 1, &value);
+    }
+    goto dispatch;
+
+do_bastore:
+    if (sp >= 3) {
+        jbyte value = static_cast<jbyte>(stack[--sp]);
+        jsize index = static_cast<jsize>(stack[--sp]);
+        jbyteArray arr = reinterpret_cast<jbyteArray>(stack[--sp]);
+        env->SetByteArrayRegion(arr, index, 1, &value);
+    }
+    goto dispatch;
+
+do_castore:
+    if (sp >= 3) {
+        jchar value = static_cast<jchar>(stack[--sp]);
+        jsize index = static_cast<jsize>(stack[--sp]);
+        jcharArray arr = reinterpret_cast<jcharArray>(stack[--sp]);
+        env->SetCharArrayRegion(arr, index, 1, &value);
+    }
+    goto dispatch;
+
+do_sastore:
+    if (sp >= 3) {
+        jshort value = static_cast<jshort>(stack[--sp]);
+        jsize index = static_cast<jsize>(stack[--sp]);
+        jshortArray arr = reinterpret_cast<jshortArray>(stack[--sp]);
+        env->SetShortArrayRegion(arr, index, 1, &value);
     }
     goto dispatch;
 

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -93,7 +93,15 @@ enum OpCode : uint8_t {
     OP_D2I = 80,   // convert double to int
     OP_D2L = 81,   // convert double to long
     OP_D2F = 82,   // convert double to float
-    OP_COUNT = 83  // helper constant with number of opcodes
+    OP_IALOAD = 83, // load from int array
+    OP_BALOAD = 84, // load from byte array
+    OP_CALOAD = 85, // load from char array
+    OP_SALOAD = 86, // load from short array
+    OP_IASTORE = 87, // store into int array
+    OP_BASTORE = 88, // store into byte array
+    OP_CASTORE = 89, // store into char array
+    OP_SASTORE = 90, // store into short array
+    OP_COUNT = 91  // helper constant with number of opcodes
 };
 
 // Every field of an instruction is lightly encrypted and decoded at

--- a/obfuscator/src/main/resources/sources/vm_jit.cpp
+++ b/obfuscator/src/main/resources/sources/vm_jit.cpp
@@ -233,6 +233,74 @@ static int64_t run_program(JNIEnv* env, int64_t* locals, size_t locals_len,
                     env->SetObjectArrayElement(arr, index, value);
                 }
                 break;
+            case OP_IALOAD:
+                if (sp >= 2) {
+                    jsize index = static_cast<jsize>(stack[--sp]);
+                    jintArray arr = reinterpret_cast<jintArray>(stack[--sp]);
+                    jint val;
+                    env->GetIntArrayRegion(arr, index, 1, &val);
+                    stack[sp++] = val;
+                }
+                break;
+            case OP_BALOAD:
+                if (sp >= 2) {
+                    jsize index = static_cast<jsize>(stack[--sp]);
+                    jbyteArray arr = reinterpret_cast<jbyteArray>(stack[--sp]);
+                    jbyte val;
+                    env->GetByteArrayRegion(arr, index, 1, &val);
+                    stack[sp++] = val;
+                }
+                break;
+            case OP_CALOAD:
+                if (sp >= 2) {
+                    jsize index = static_cast<jsize>(stack[--sp]);
+                    jcharArray arr = reinterpret_cast<jcharArray>(stack[--sp]);
+                    jchar val;
+                    env->GetCharArrayRegion(arr, index, 1, &val);
+                    stack[sp++] = val;
+                }
+                break;
+            case OP_SALOAD:
+                if (sp >= 2) {
+                    jsize index = static_cast<jsize>(stack[--sp]);
+                    jshortArray arr = reinterpret_cast<jshortArray>(stack[--sp]);
+                    jshort val;
+                    env->GetShortArrayRegion(arr, index, 1, &val);
+                    stack[sp++] = val;
+                }
+                break;
+            case OP_IASTORE:
+                if (sp >= 3) {
+                    jint value = static_cast<jint>(stack[--sp]);
+                    jsize index = static_cast<jsize>(stack[--sp]);
+                    jintArray arr = reinterpret_cast<jintArray>(stack[--sp]);
+                    env->SetIntArrayRegion(arr, index, 1, &value);
+                }
+                break;
+            case OP_BASTORE:
+                if (sp >= 3) {
+                    jbyte value = static_cast<jbyte>(stack[--sp]);
+                    jsize index = static_cast<jsize>(stack[--sp]);
+                    jbyteArray arr = reinterpret_cast<jbyteArray>(stack[--sp]);
+                    env->SetByteArrayRegion(arr, index, 1, &value);
+                }
+                break;
+            case OP_CASTORE:
+                if (sp >= 3) {
+                    jchar value = static_cast<jchar>(stack[--sp]);
+                    jsize index = static_cast<jsize>(stack[--sp]);
+                    jcharArray arr = reinterpret_cast<jcharArray>(stack[--sp]);
+                    env->SetCharArrayRegion(arr, index, 1, &value);
+                }
+                break;
+            case OP_SASTORE:
+                if (sp >= 3) {
+                    jshort value = static_cast<jshort>(stack[--sp]);
+                    jsize index = static_cast<jsize>(stack[--sp]);
+                    jshortArray arr = reinterpret_cast<jshortArray>(stack[--sp]);
+                    env->SetShortArrayRegion(arr, index, 1, &value);
+                }
+                break;
             case OP_INVOKESTATIC:
                 // simplified: treat as no-op
                 break;

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorPrimitiveArrayTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorPrimitiveArrayTest.java
@@ -1,0 +1,185 @@
+package by.radioegor146;
+
+import by.radioegor146.instructions.VmTranslator;
+import by.radioegor146.instructions.VmTranslator.Instruction;
+import by.radioegor146.instructions.VmTranslator.VmOpcodes;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VmTranslatorPrimitiveArrayTest {
+
+    static class SampleArrays {
+        static int processInt(int[] arr) {
+            int tmp = arr[0];
+            arr[1] = tmp;
+            return arr[1];
+        }
+        static byte processByte(byte[] arr) {
+            byte tmp = arr[0];
+            arr[1] = tmp;
+            return arr[1];
+        }
+        static char processChar(char[] arr) {
+            char tmp = arr[0];
+            arr[1] = tmp;
+            return arr[1];
+        }
+        static short processShort(short[] arr) {
+            short tmp = arr[0];
+            arr[1] = tmp;
+            return arr[1];
+        }
+    }
+
+    private long run(Instruction[] code, long[] locals, Object[] oLocals) {
+        Object[] stack = new Object[256];
+        int sp = 0;
+        for (int pc = 0; pc < code.length; pc++) {
+            Instruction ins = code[pc];
+            switch (ins.opcode) {
+                case VmOpcodes.OP_PUSH:
+                    stack[sp++] = ins.operand;
+                    break;
+                case VmOpcodes.OP_LOAD:
+                    stack[sp++] = locals[(int) ins.operand];
+                    break;
+                case VmOpcodes.OP_STORE:
+                    locals[(int) ins.operand] = (long) stack[--sp];
+                    break;
+                case VmOpcodes.OP_ALOAD:
+                    stack[sp++] = oLocals[(int) ins.operand];
+                    break;
+                case VmOpcodes.OP_ASTORE:
+                    oLocals[(int) ins.operand] = stack[--sp];
+                    break;
+                case VmOpcodes.OP_IALOAD: {
+                    int idx = (int) (long) stack[--sp];
+                    int[] arr = (int[]) stack[--sp];
+                    stack[sp++] = (long) arr[idx];
+                    break;
+                }
+                case VmOpcodes.OP_BALOAD: {
+                    int idx = (int) (long) stack[--sp];
+                    byte[] arr = (byte[]) stack[--sp];
+                    stack[sp++] = (long) arr[idx];
+                    break;
+                }
+                case VmOpcodes.OP_CALOAD: {
+                    int idx = (int) (long) stack[--sp];
+                    char[] arr = (char[]) stack[--sp];
+                    stack[sp++] = (long) arr[idx];
+                    break;
+                }
+                case VmOpcodes.OP_SALOAD: {
+                    int idx = (int) (long) stack[--sp];
+                    short[] arr = (short[]) stack[--sp];
+                    stack[sp++] = (long) arr[idx];
+                    break;
+                }
+                case VmOpcodes.OP_IASTORE: {
+                    long val = (long) stack[--sp];
+                    int idx = (int) (long) stack[--sp];
+                    int[] arr = (int[]) stack[--sp];
+                    arr[idx] = (int) val;
+                    break;
+                }
+                case VmOpcodes.OP_BASTORE: {
+                    long val = (long) stack[--sp];
+                    int idx = (int) (long) stack[--sp];
+                    byte[] arr = (byte[]) stack[--sp];
+                    arr[idx] = (byte) val;
+                    break;
+                }
+                case VmOpcodes.OP_CASTORE: {
+                    long val = (long) stack[--sp];
+                    int idx = (int) (long) stack[--sp];
+                    char[] arr = (char[]) stack[--sp];
+                    arr[idx] = (char) val;
+                    break;
+                }
+                case VmOpcodes.OP_SASTORE: {
+                    long val = (long) stack[--sp];
+                    int idx = (int) (long) stack[--sp];
+                    short[] arr = (short[]) stack[--sp];
+                    arr[idx] = (short) val;
+                    break;
+                }
+                case VmOpcodes.OP_HALT:
+                    return sp > 0 ? (long) stack[sp - 1] : 0;
+                default:
+                    throw new IllegalStateException("Unknown opcode: " + ins.opcode);
+            }
+        }
+        return sp > 0 ? (long) stack[sp - 1] : 0;
+    }
+
+    @Test
+    public void testPrimitiveArrays() throws Exception {
+        VmTranslator translator = new VmTranslator();
+        ClassReader cr = new ClassReader(SampleArrays.class.getName());
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+
+        // int[]
+        MethodNode mnI = cn.methods.stream().filter(m -> m.name.equals("processInt")).findFirst().orElseThrow();
+        Instruction[] codeI = translator.translate(mnI);
+        assertNotNull(codeI);
+        assertTrue(Arrays.stream(codeI).anyMatch(i -> i.opcode == VmOpcodes.OP_IALOAD));
+        assertTrue(Arrays.stream(codeI).anyMatch(i -> i.opcode == VmOpcodes.OP_IASTORE));
+        long[] localsI = new long[2];
+        Object[] oLocalsI = new Object[1];
+        int[] arrI = new int[]{5,0};
+        oLocalsI[0] = arrI;
+        long resI = run(codeI, localsI, oLocalsI);
+        assertEquals(SampleArrays.processInt(new int[]{5,0}), (int) resI);
+        assertEquals(arrI[0], arrI[1]);
+
+        // byte[]
+        MethodNode mnB = cn.methods.stream().filter(m -> m.name.equals("processByte")).findFirst().orElseThrow();
+        Instruction[] codeB = translator.translate(mnB);
+        assertNotNull(codeB);
+        assertTrue(Arrays.stream(codeB).anyMatch(i -> i.opcode == VmOpcodes.OP_BALOAD));
+        assertTrue(Arrays.stream(codeB).anyMatch(i -> i.opcode == VmOpcodes.OP_BASTORE));
+        long[] localsB = new long[2];
+        Object[] oLocalsB = new Object[1];
+        byte[] arrB = new byte[]{3,0};
+        oLocalsB[0] = arrB;
+        long resB = run(codeB, localsB, oLocalsB);
+        assertEquals(SampleArrays.processByte(new byte[]{3,0}), (byte) resB);
+        assertEquals(arrB[0], arrB[1]);
+
+        // char[]
+        MethodNode mnC = cn.methods.stream().filter(m -> m.name.equals("processChar")).findFirst().orElseThrow();
+        Instruction[] codeC = translator.translate(mnC);
+        assertNotNull(codeC);
+        assertTrue(Arrays.stream(codeC).anyMatch(i -> i.opcode == VmOpcodes.OP_CALOAD));
+        assertTrue(Arrays.stream(codeC).anyMatch(i -> i.opcode == VmOpcodes.OP_CASTORE));
+        long[] localsC = new long[2];
+        Object[] oLocalsC = new Object[1];
+        char[] arrC = new char[]{'a','\0'};
+        oLocalsC[0] = arrC;
+        long resC = run(codeC, localsC, oLocalsC);
+        assertEquals(SampleArrays.processChar(new char[]{'a','\0'}), (char) resC);
+        assertEquals(arrC[0], arrC[1]);
+
+        // short[]
+        MethodNode mnS = cn.methods.stream().filter(m -> m.name.equals("processShort")).findFirst().orElseThrow();
+        Instruction[] codeS = translator.translate(mnS);
+        assertNotNull(codeS);
+        assertTrue(Arrays.stream(codeS).anyMatch(i -> i.opcode == VmOpcodes.OP_SALOAD));
+        assertTrue(Arrays.stream(codeS).anyMatch(i -> i.opcode == VmOpcodes.OP_SASTORE));
+        long[] localsS = new long[2];
+        Object[] oLocalsS = new Object[1];
+        short[] arrS = new short[]{7,0};
+        oLocalsS[0] = arrS;
+        long resS = run(codeS, localsS, oLocalsS);
+        assertEquals(SampleArrays.processShort(new short[]{7,0}), (short) resS);
+        assertEquals(arrS[0], arrS[1]);
+    }
+}


### PR DESCRIPTION
## Summary
- extend micro VM with primitive array load/store opcodes
- translate JVM primitive array operations to new VM opcodes
- cover primitive array read/write via unit tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c51a0966688332bc1e6bc361f89da9