### PR TITLE
Implement JVM-style stack manipulation ops

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -223,6 +223,13 @@ public class VmTranslator {
         public static final int OP_IF_ICMPLE_W = 119;
         public static final int OP_IF_ICMPGT_W = 120;
         public static final int OP_IF_ICMPGE_W = 121;
+        public static final int OP_POP = 122;
+        public static final int OP_POP2 = 123;
+        public static final int OP_DUP_X1 = 124;
+        public static final int OP_DUP_X2 = 125;
+        public static final int OP_DUP2 = 126;
+        public static final int OP_DUP2_X1 = 127;
+        public static final int OP_DUP2_X2 = 128;
     }
 
     /**
@@ -253,6 +260,33 @@ public class VmTranslator {
         for (AbstractInsnNode insn = method.instructions.getFirst(); insn != null; insn = insn.getNext()) {
             int opcode = insn.getOpcode();
             switch (opcode) {
+                case Opcodes.POP:
+                    result.add(new Instruction(VmOpcodes.OP_POP, 0));
+                    break;
+                case Opcodes.POP2:
+                    result.add(new Instruction(VmOpcodes.OP_POP2, 0));
+                    break;
+                case Opcodes.DUP:
+                    result.add(new Instruction(VmOpcodes.OP_DUP, 0));
+                    break;
+                case Opcodes.DUP_X1:
+                    result.add(new Instruction(VmOpcodes.OP_DUP_X1, 0));
+                    break;
+                case Opcodes.DUP_X2:
+                    result.add(new Instruction(VmOpcodes.OP_DUP_X2, 0));
+                    break;
+                case Opcodes.DUP2:
+                    result.add(new Instruction(VmOpcodes.OP_DUP2, 0));
+                    break;
+                case Opcodes.DUP2_X1:
+                    result.add(new Instruction(VmOpcodes.OP_DUP2_X1, 0));
+                    break;
+                case Opcodes.DUP2_X2:
+                    result.add(new Instruction(VmOpcodes.OP_DUP2_X2, 0));
+                    break;
+                case Opcodes.SWAP:
+                    result.add(new Instruction(VmOpcodes.OP_SWAP, 0));
+                    break;
                 case Opcodes.ILOAD:
                     result.add(new Instruction(VmOpcodes.OP_LOAD, ((VarInsnNode) insn).var));
                     break;

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -323,6 +323,13 @@ dispatch:
         case OP_JUNK2: goto do_junk2;
         case OP_SWAP:  goto do_swap;
         case OP_DUP:   goto do_dup;
+        case OP_POP:   goto do_pop;
+        case OP_POP2:  goto do_pop2;
+        case OP_DUP_X1: goto do_dup_x1;
+        case OP_DUP_X2: goto do_dup_x2;
+        case OP_DUP2:  goto do_dup2;
+        case OP_DUP2_X1: goto do_dup2_x1;
+        case OP_DUP2_X2: goto do_dup2_x2;
         case OP_LOAD:  goto do_load;
         case OP_LLOAD:
         case OP_FLOAD:
@@ -643,6 +650,76 @@ do_swap:
 
 do_dup:
     if (sp >= 1 && sp < 256) stack[sp++] = stack[sp - 1];
+    goto dispatch;
+
+do_pop:
+    if (sp >= 1) --sp;
+    goto dispatch;
+
+do_pop2:
+    if (sp >= 2) sp -= 2;
+    goto dispatch;
+
+do_dup_x1:
+    if (sp >= 2 && sp < 256) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        stack[sp - 2] = v1;
+        stack[sp - 1] = v2;
+        stack[sp++] = v1;
+    }
+    goto dispatch;
+
+do_dup_x2:
+    if (sp >= 3 && sp < 256) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        int64_t v3 = stack[sp - 3];
+        stack[sp - 3] = v1;
+        stack[sp - 2] = v3;
+        stack[sp - 1] = v2;
+        stack[sp++] = v1;
+    }
+    goto dispatch;
+
+do_dup2:
+    if (sp >= 2 && sp < 255) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        stack[sp] = v2;
+        stack[sp + 1] = v1;
+        sp += 2;
+    }
+    goto dispatch;
+
+do_dup2_x1:
+    if (sp >= 3 && sp < 255) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        int64_t v3 = stack[sp - 3];
+        stack[sp - 3] = v2;
+        stack[sp - 2] = v1;
+        stack[sp - 1] = v3;
+        stack[sp] = v2;
+        stack[sp + 1] = v1;
+        sp += 2;
+    }
+    goto dispatch;
+
+do_dup2_x2:
+    if (sp >= 4 && sp < 255) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        int64_t v3 = stack[sp - 3];
+        int64_t v4 = stack[sp - 4];
+        stack[sp - 4] = v2;
+        stack[sp - 3] = v1;
+        stack[sp - 2] = v4;
+        stack[sp - 1] = v3;
+        stack[sp] = v2;
+        stack[sp + 1] = v1;
+        sp += 2;
+    }
     goto dispatch;
 
 do_load:

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -132,7 +132,14 @@ enum OpCode : uint8_t {
     OP_IF_ICMPLE_W = 119,  // wide int compare le
     OP_IF_ICMPGT_W = 120,  // wide int compare gt
     OP_IF_ICMPGE_W = 121,  // wide int compare ge
-    OP_COUNT = 122         // helper constant with number of opcodes
+    OP_POP  = 122, // pop top stack value
+    OP_POP2 = 123, // pop top two stack values
+    OP_DUP_X1 = 124, // duplicate top value and insert two down
+    OP_DUP_X2 = 125, // duplicate top value and insert three down
+    OP_DUP2 = 126,   // duplicate top two values
+    OP_DUP2_X1 = 127, // duplicate top two values and insert two down
+    OP_DUP2_X2 = 128, // duplicate top two values and insert three down
+    OP_COUNT = 129         // helper constant with number of opcodes
 };
 
 // Every field of an instruction is lightly encrypted and decoded at

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorStackOpTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorStackOpTest.java
@@ -1,0 +1,260 @@
+package by.radioegor146;
+
+import by.radioegor146.instructions.VmTranslator;
+import by.radioegor146.instructions.VmTranslator.Instruction;
+import by.radioegor146.instructions.VmTranslator.VmOpcodes;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VmTranslatorStackOpTest {
+
+    private long run(Instruction[] code) {
+        long[] stack = new long[256];
+        int sp = 0;
+        for (Instruction ins : code) {
+            switch (ins.opcode) {
+                case VmOpcodes.OP_PUSH:
+                    stack[sp++] = ins.operand;
+                    break;
+                case VmOpcodes.OP_ADD:
+                    stack[sp - 2] += stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_SUB:
+                    stack[sp - 2] -= stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_POP:
+                    if (sp > 0) sp--;
+                    break;
+                case VmOpcodes.OP_POP2:
+                    if (sp > 1) sp -= 2;
+                    break;
+                case VmOpcodes.OP_DUP:
+                    stack[sp] = stack[sp - 1];
+                    sp++;
+                    break;
+                case VmOpcodes.OP_DUP_X1: {
+                    long v1 = stack[sp - 1];
+                    long v2 = stack[sp - 2];
+                    stack[sp - 2] = v1;
+                    stack[sp - 1] = v2;
+                    stack[sp++] = v1;
+                    break;
+                }
+                case VmOpcodes.OP_DUP_X2: {
+                    long v1 = stack[sp - 1];
+                    long v2 = stack[sp - 2];
+                    long v3 = stack[sp - 3];
+                    stack[sp - 3] = v1;
+                    stack[sp - 2] = v3;
+                    stack[sp - 1] = v2;
+                    stack[sp++] = v1;
+                    break;
+                }
+                case VmOpcodes.OP_DUP2: {
+                    long v1 = stack[sp - 1];
+                    long v2 = stack[sp - 2];
+                    stack[sp] = v2;
+                    stack[sp + 1] = v1;
+                    sp += 2;
+                    break;
+                }
+                case VmOpcodes.OP_DUP2_X1: {
+                    long v1 = stack[sp - 1];
+                    long v2 = stack[sp - 2];
+                    long v3 = stack[sp - 3];
+                    stack[sp - 3] = v2;
+                    stack[sp - 2] = v1;
+                    stack[sp - 1] = v3;
+                    stack[sp] = v2;
+                    stack[sp + 1] = v1;
+                    sp += 2;
+                    break;
+                }
+                case VmOpcodes.OP_DUP2_X2: {
+                    long v1 = stack[sp - 1];
+                    long v2 = stack[sp - 2];
+                    long v3 = stack[sp - 3];
+                    long v4 = stack[sp - 4];
+                    stack[sp - 4] = v2;
+                    stack[sp - 3] = v1;
+                    stack[sp - 2] = v4;
+                    stack[sp - 1] = v3;
+                    stack[sp] = v2;
+                    stack[sp + 1] = v1;
+                    sp += 2;
+                    break;
+                }
+                case VmOpcodes.OP_SWAP: {
+                    long tmp = stack[sp - 1];
+                    stack[sp - 1] = stack[sp - 2];
+                    stack[sp - 2] = tmp;
+                    break;
+                }
+                case VmOpcodes.OP_HALT:
+                    return sp > 0 ? stack[sp - 1] : 0;
+                default:
+                    throw new IllegalStateException("Unknown opcode " + ins.opcode);
+            }
+        }
+        return sp > 0 ? stack[sp - 1] : 0;
+    }
+
+    @Test
+    public void testPopAndPop2() {
+        VmTranslator tr = new VmTranslator();
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.POP));
+        il.add(new InsnNode(Opcodes.ICONST_3));
+        il.add(new InsnNode(Opcodes.ICONST_4));
+        il.add(new InsnNode(Opcodes.POP2));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        mn.maxStack = 4;
+        mn.maxLocals = 0;
+        Instruction[] code = tr.translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_POP));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_POP2));
+        assertEquals(1, run(code));
+    }
+
+    @Test
+    public void testDupVariants() {
+        VmTranslator tr = new VmTranslator();
+
+        // DUP
+        MethodNode dup = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = dup.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.DUP));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        dup.maxStack = 2;
+        dup.maxLocals = 0;
+        Instruction[] codeDup = tr.translate(dup);
+        assertNotNull(codeDup);
+        assertTrue(Arrays.stream(codeDup).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP));
+        assertEquals(2, run(codeDup));
+
+        // DUP_X1
+        MethodNode dupx1 = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        il = dupx1.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.DUP_X1));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        dupx1.maxStack = 3;
+        dupx1.maxLocals = 0;
+        Instruction[] codeDupX1 = tr.translate(dupx1);
+        assertNotNull(codeDupX1);
+        assertTrue(Arrays.stream(codeDupX1).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP_X1));
+        assertEquals(5, run(codeDupX1));
+
+        // DUP_X2
+        MethodNode dupx2 = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        il = dupx2.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.ICONST_3));
+        il.add(new InsnNode(Opcodes.DUP_X2));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        dupx2.maxStack = 4;
+        dupx2.maxLocals = 0;
+        Instruction[] codeDupX2 = tr.translate(dupx2);
+        assertNotNull(codeDupX2);
+        assertTrue(Arrays.stream(codeDupX2).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP_X2));
+        assertEquals(9, run(codeDupX2));
+
+        // DUP2
+        MethodNode dup2 = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        il = dup2.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.DUP2));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        dup2.maxStack = 4;
+        dup2.maxLocals = 0;
+        Instruction[] codeDup2 = tr.translate(dup2);
+        assertNotNull(codeDup2);
+        assertTrue(Arrays.stream(codeDup2).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2));
+        assertEquals(6, run(codeDup2));
+
+        // DUP2_X1
+        MethodNode dup2x1 = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        il = dup2x1.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.ICONST_3));
+        il.add(new InsnNode(Opcodes.DUP2_X1));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        dup2x1.maxStack = 5;
+        dup2x1.maxLocals = 0;
+        Instruction[] codeDup2X1 = tr.translate(dup2x1);
+        assertNotNull(codeDup2X1);
+        assertTrue(Arrays.stream(codeDup2X1).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2_X1));
+        assertEquals(11, run(codeDup2X1));
+
+        // DUP2_X2
+        MethodNode dup2x2 = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        il = dup2x2.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.ICONST_3));
+        il.add(new InsnNode(Opcodes.ICONST_4));
+        il.add(new InsnNode(Opcodes.DUP2_X2));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        dup2x2.maxStack = 6;
+        dup2x2.maxLocals = 0;
+        Instruction[] codeDup2X2 = tr.translate(dup2x2);
+        assertNotNull(codeDup2X2);
+        assertTrue(Arrays.stream(codeDup2X2).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2_X2));
+        assertEquals(17, run(codeDup2X2));
+    }
+
+    @Test
+    public void testSwap() {
+        VmTranslator tr = new VmTranslator();
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.SWAP));
+        il.add(new InsnNode(Opcodes.ISUB));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        mn.maxStack = 2;
+        mn.maxLocals = 0;
+        Instruction[] code = tr.translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_SWAP));
+        assertEquals(1, run(code));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add POP/POP2 and DUP* opcodes to VM
- map JVM stack instructions in `VmTranslator`
- cover stack operations with dedicated translator tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b10e0ec083328468c17b11eabad2