### PR TITLE
Support JVM-style stack operations in micro VM

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -223,6 +223,13 @@ public class VmTranslator {
         public static final int OP_IF_ICMPLE_W = 119;
         public static final int OP_IF_ICMPGT_W = 120;
         public static final int OP_IF_ICMPGE_W = 121;
+        public static final int OP_POP = 122;
+        public static final int OP_POP2 = 123;
+        public static final int OP_DUP_X1 = 124;
+        public static final int OP_DUP_X2 = 125;
+        public static final int OP_DUP2 = 126;
+        public static final int OP_DUP2_X1 = 127;
+        public static final int OP_DUP2_X2 = 128;
     }
 
     /**
@@ -250,26 +257,31 @@ public class VmTranslator {
         int classIndex = 0;
         Map<String, Integer> fieldIds = new HashMap<>();
         int fieldIndex = 0;
+        Deque<Integer> typeStack = new ArrayDeque<>();
         for (AbstractInsnNode insn = method.instructions.getFirst(); insn != null; insn = insn.getNext()) {
             int opcode = insn.getOpcode();
             switch (opcode) {
                 case Opcodes.ILOAD:
                     result.add(new Instruction(VmOpcodes.OP_LOAD, ((VarInsnNode) insn).var));
+                    typeStack.push(1);
                     break;
                 case 26: // ILOAD_0
                 case 27: // ILOAD_1
                 case 28: // ILOAD_2
                 case 29: // ILOAD_3
                     result.add(new Instruction(VmOpcodes.OP_LOAD, opcode - 26));
+                    typeStack.push(1);
                     break;
                 case Opcodes.LLOAD:
                     result.add(new Instruction(VmOpcodes.OP_LLOAD, ((VarInsnNode) insn).var));
+                    typeStack.push(2);
                     break;
                 case 30: // LLOAD_0
                 case 31: // LLOAD_1
                 case 32: // LLOAD_2
                 case 33: // LLOAD_3
                     result.add(new Instruction(VmOpcodes.OP_LLOAD, opcode - 30));
+                    typeStack.push(2);
                     break;
                 case Opcodes.FLOAD:
                     result.add(new Instruction(VmOpcodes.OP_FLOAD, ((VarInsnNode) insn).var));
@@ -354,6 +366,99 @@ public class VmTranslator {
                     break;
                 case Opcodes.IUSHR:
                     result.add(new Instruction(VmOpcodes.OP_USHR, 0));
+                    break;
+                case Opcodes.POP:
+                    result.add(new Instruction(VmOpcodes.OP_POP, 0));
+                    if (!typeStack.isEmpty()) typeStack.pop();
+                    break;
+                case Opcodes.POP2:
+                    if (!typeStack.isEmpty() && typeStack.peek() == 2) {
+                        typeStack.pop();
+                        result.add(new Instruction(VmOpcodes.OP_POP, 0));
+                    } else {
+                        if (!typeStack.isEmpty()) typeStack.pop();
+                        if (!typeStack.isEmpty()) typeStack.pop();
+                        result.add(new Instruction(VmOpcodes.OP_POP2, 0));
+                    }
+                    break;
+                case Opcodes.DUP:
+                    result.add(new Instruction(VmOpcodes.OP_DUP, 0));
+                    if (!typeStack.isEmpty()) typeStack.push(typeStack.peek());
+                    break;
+                case Opcodes.DUP_X1:
+                    result.add(new Instruction(VmOpcodes.OP_DUP_X1, 0));
+                    if (typeStack.size() >= 2) {
+                        int t1 = typeStack.pop();
+                        int t2 = typeStack.pop();
+                        typeStack.push(t1);
+                        typeStack.push(t2);
+                        typeStack.push(t1);
+                    }
+                    break;
+                case Opcodes.DUP_X2:
+                    result.add(new Instruction(VmOpcodes.OP_DUP_X2, 0));
+                    if (typeStack.size() >= 3) {
+                        int t1 = typeStack.pop();
+                        int t2 = typeStack.pop();
+                        int t3 = typeStack.pop();
+                        typeStack.push(t1);
+                        typeStack.push(t3);
+                        typeStack.push(t2);
+                        typeStack.push(t1);
+                    }
+                    break;
+                case Opcodes.DUP2:
+                    if (!typeStack.isEmpty() && typeStack.peek() == 2) {
+                        result.add(new Instruction(VmOpcodes.OP_DUP, 0));
+                        typeStack.push(2);
+                    } else {
+                        result.add(new Instruction(VmOpcodes.OP_DUP2, 0));
+                        if (typeStack.size() >= 2) {
+                            int t1 = typeStack.pop();
+                            int t2 = typeStack.pop();
+                            typeStack.push(t2);
+                            typeStack.push(t1);
+                            typeStack.push(t2);
+                            typeStack.push(t1);
+                        }
+                    }
+                    break;
+                case Opcodes.DUP2_X1:
+                    result.add(new Instruction(VmOpcodes.OP_DUP2_X1, 0));
+                    if (typeStack.size() >= 3) {
+                        int t1 = typeStack.pop();
+                        int t2 = typeStack.pop();
+                        int t3 = typeStack.pop();
+                        typeStack.push(t2);
+                        typeStack.push(t1);
+                        typeStack.push(t3);
+                        typeStack.push(t2);
+                        typeStack.push(t1);
+                    }
+                    break;
+                case Opcodes.DUP2_X2:
+                    result.add(new Instruction(VmOpcodes.OP_DUP2_X2, 0));
+                    if (typeStack.size() >= 4) {
+                        int t1 = typeStack.pop();
+                        int t2 = typeStack.pop();
+                        int t3 = typeStack.pop();
+                        int t4 = typeStack.pop();
+                        typeStack.push(t2);
+                        typeStack.push(t1);
+                        typeStack.push(t4);
+                        typeStack.push(t3);
+                        typeStack.push(t2);
+                        typeStack.push(t1);
+                    }
+                    break;
+                case Opcodes.SWAP:
+                    result.add(new Instruction(VmOpcodes.OP_SWAP, 0));
+                    if (typeStack.size() >= 2) {
+                        int t1 = typeStack.pop();
+                        int t2 = typeStack.pop();
+                        typeStack.push(t1);
+                        typeStack.push(t2);
+                    }
                     break;
                 case Opcodes.LAND:
                     result.add(new Instruction(VmOpcodes.OP_LAND, 0));
@@ -492,12 +597,15 @@ public class VmTranslator {
                     int val = opcode - Opcodes.ICONST_0;
                     if (opcode == Opcodes.ICONST_M1) val = -1;
                     result.add(new Instruction(VmOpcodes.OP_PUSH, val));
+                    typeStack.push(1);
                     break;
                 case Opcodes.LCONST_0:
                     result.add(new Instruction(VmOpcodes.OP_LCONST_0, 0));
+                    typeStack.push(2);
                     break;
                 case Opcodes.LCONST_1:
                     result.add(new Instruction(VmOpcodes.OP_LCONST_1, 0));
+                    typeStack.push(2);
                     break;
                 case Opcodes.FCONST_0:
                     result.add(new Instruction(VmOpcodes.OP_FCONST_0, 0));

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -323,6 +323,13 @@ dispatch:
         case OP_JUNK2: goto do_junk2;
         case OP_SWAP:  goto do_swap;
         case OP_DUP:   goto do_dup;
+        case OP_POP:   goto do_pop;
+        case OP_POP2:  goto do_pop2;
+        case OP_DUP_X1: goto do_dup_x1;
+        case OP_DUP_X2: goto do_dup_x2;
+        case OP_DUP2:  goto do_dup2;
+        case OP_DUP2_X1: goto do_dup2_x1;
+        case OP_DUP2_X2: goto do_dup2_x2;
         case OP_LOAD:  goto do_load;
         case OP_LLOAD:
         case OP_FLOAD:
@@ -643,6 +650,74 @@ do_swap:
 
 do_dup:
     if (sp >= 1 && sp < 256) stack[sp++] = stack[sp - 1];
+    goto dispatch;
+
+do_pop:
+    if (sp >= 1) --sp;
+    goto dispatch;
+
+do_pop2:
+    if (sp >= 2) sp -= 2;
+    goto dispatch;
+
+do_dup_x1:
+    if (sp >= 2 && sp < 256) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        stack[sp - 2] = v1;
+        stack[sp - 1] = v2;
+        stack[sp++] = v1;
+    }
+    goto dispatch;
+
+do_dup_x2:
+    if (sp >= 3 && sp < 256) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        int64_t v3 = stack[sp - 3];
+        stack[sp - 3] = v1;
+        stack[sp - 2] = v3;
+        stack[sp - 1] = v2;
+        stack[sp++] = v1;
+    }
+    goto dispatch;
+
+do_dup2:
+    if (sp >= 2 && sp < 255) {
+        stack[sp] = stack[sp - 2];
+        stack[sp + 1] = stack[sp - 1];
+        sp += 2;
+    }
+    goto dispatch;
+
+do_dup2_x1:
+    if (sp >= 3 && sp < 255) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        int64_t v3 = stack[sp - 3];
+        stack[sp - 3] = v2;
+        stack[sp - 2] = v1;
+        stack[sp - 1] = v3;
+        stack[sp] = v2;
+        stack[sp + 1] = v1;
+        sp += 2;
+    }
+    goto dispatch;
+
+do_dup2_x2:
+    if (sp >= 4 && sp < 255) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        int64_t v3 = stack[sp - 3];
+        int64_t v4 = stack[sp - 4];
+        stack[sp - 4] = v2;
+        stack[sp - 3] = v1;
+        stack[sp - 2] = v4;
+        stack[sp - 1] = v3;
+        stack[sp] = v2;
+        stack[sp + 1] = v1;
+        sp += 2;
+    }
     goto dispatch;
 
 do_load:

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -132,7 +132,14 @@ enum OpCode : uint8_t {
     OP_IF_ICMPLE_W = 119,  // wide int compare le
     OP_IF_ICMPGT_W = 120,  // wide int compare gt
     OP_IF_ICMPGE_W = 121,  // wide int compare ge
-    OP_COUNT = 122         // helper constant with number of opcodes
+    OP_POP = 122,          // pop top stack value
+    OP_POP2 = 123,         // pop two top stack values
+    OP_DUP_X1 = 124,       // dup top and insert one value down
+    OP_DUP_X2 = 125,       // dup top and insert two values down
+    OP_DUP2 = 126,         // dup top two stack values
+    OP_DUP2_X1 = 127,      // dup top two and insert one value down
+    OP_DUP2_X2 = 128,      // dup top two and insert two values down
+    OP_COUNT = 129         // helper constant with number of opcodes
 };
 
 // Every field of an instruction is lightly encrypted and decoded at

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorStackOpTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorStackOpTest.java
@@ -1,0 +1,168 @@
+package by.radioegor146;
+
+import by.radioegor146.instructions.VmTranslator;
+import by.radioegor146.instructions.VmTranslator.Instruction;
+import by.radioegor146.instructions.VmTranslator.VmOpcodes;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VmTranslatorStackOpTest {
+
+    private long run(Instruction[] code, long[] locals) {
+        long[] stack = new long[256];
+        int sp = 0;
+        for (Instruction ins : code) {
+            switch (ins.opcode) {
+                case VmOpcodes.OP_PUSH:
+                    stack[sp++] = ins.operand;
+                    break;
+                case VmOpcodes.OP_DUP:
+                    stack[sp] = stack[sp - 1];
+                    sp++;
+                    break;
+                case VmOpcodes.OP_SWAP: {
+                    long t = stack[sp - 1];
+                    stack[sp - 1] = stack[sp - 2];
+                    stack[sp - 2] = t;
+                    break;
+                }
+                case VmOpcodes.OP_POP:
+                    {
+                        long unused = stack[--sp];
+                    }
+                    break;
+                case VmOpcodes.OP_POP2:
+                    sp -= 2;
+                    {
+                        long unused = stack[sp];
+                    }
+                    break;
+                case VmOpcodes.OP_DUP_X1: {
+                    long v1 = stack[sp - 1];
+                    long v2 = stack[sp - 2];
+                    stack[sp - 2] = v1;
+                    stack[sp - 1] = v2;
+                    stack[sp++] = v1;
+                    break;
+                }
+                case VmOpcodes.OP_DUP_X2: {
+                    long v1 = stack[sp - 1];
+                    long v2 = stack[sp - 2];
+                    long v3 = stack[sp - 3];
+                    stack[sp - 3] = v1;
+                    stack[sp - 2] = v3;
+                    stack[sp - 1] = v2;
+                    stack[sp++] = v1;
+                    break;
+                }
+                case VmOpcodes.OP_DUP2:
+                    stack[sp] = stack[sp - 2];
+                    stack[sp + 1] = stack[sp - 1];
+                    sp += 2;
+                    break;
+                case VmOpcodes.OP_DUP2_X1: {
+                    long v1 = stack[sp - 1];
+                    long v2 = stack[sp - 2];
+                    long v3 = stack[sp - 3];
+                    stack[sp - 3] = v2;
+                    stack[sp - 2] = v1;
+                    stack[sp - 1] = v3;
+                    stack[sp] = v2;
+                    stack[sp + 1] = v1;
+                    sp += 2;
+                    break;
+                }
+                case VmOpcodes.OP_DUP2_X2: {
+                    long v1 = stack[sp - 1];
+                    long v2 = stack[sp - 2];
+                    long v3 = stack[sp - 3];
+                    long v4 = stack[sp - 4];
+                    stack[sp - 4] = v2;
+                    stack[sp - 3] = v1;
+                    stack[sp - 2] = v4;
+                    stack[sp - 1] = v3;
+                    stack[sp] = v2;
+                    stack[sp + 1] = v1;
+                    sp += 2;
+                    break;
+                }
+                case VmOpcodes.OP_ADD:
+                    stack[sp - 2] += stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_HALT:
+                    return sp > 0 ? stack[sp - 1] : 0;
+                default:
+                    throw new IllegalStateException("Unknown opcode: " + ins.opcode);
+            }
+        }
+        return sp > 0 ? stack[sp - 1] : 0;
+    }
+
+    @Test
+    public void testTranslateStackOps() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()V", null, null);
+        InsnList ins = mn.instructions;
+        ins.add(new InsnNode(Opcodes.ICONST_1));
+        ins.add(new InsnNode(Opcodes.ICONST_2));
+        ins.add(new InsnNode(Opcodes.DUP_X1));
+        ins.add(new InsnNode(Opcodes.POP2));
+        ins.add(new InsnNode(Opcodes.ICONST_3));
+        ins.add(new InsnNode(Opcodes.ICONST_4));
+        ins.add(new InsnNode(Opcodes.DUP_X2));
+        ins.add(new InsnNode(Opcodes.POP2));
+        ins.add(new InsnNode(Opcodes.ICONST_5));
+        ins.add(new InsnNode(Opcodes.ICONST_1));
+        ins.add(new InsnNode(Opcodes.DUP2));
+        ins.add(new InsnNode(Opcodes.POP2));
+        ins.add(new InsnNode(Opcodes.ICONST_2));
+        ins.add(new InsnNode(Opcodes.ICONST_3));
+        ins.add(new InsnNode(Opcodes.ICONST_4));
+        ins.add(new InsnNode(Opcodes.DUP2_X1));
+        ins.add(new InsnNode(Opcodes.POP2));
+        ins.add(new InsnNode(Opcodes.ICONST_1));
+        ins.add(new InsnNode(Opcodes.ICONST_2));
+        ins.add(new InsnNode(Opcodes.ICONST_3));
+        ins.add(new InsnNode(Opcodes.ICONST_4));
+        ins.add(new InsnNode(Opcodes.DUP2_X2));
+        ins.add(new InsnNode(Opcodes.POP2));
+        ins.add(new InsnNode(Opcodes.ICONST_0));
+        ins.add(new InsnNode(Opcodes.IRETURN));
+        VmTranslator translator = new VmTranslator();
+        Instruction[] code = translator.translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP_X1));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP_X2));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2_X1));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2_X2));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_POP2));
+    }
+
+    @Test
+    public void testExecutionAndUnderflow() {
+        Instruction[] code = new Instruction[]{
+                new Instruction(VmOpcodes.OP_PUSH, 1),
+                new Instruction(VmOpcodes.OP_PUSH, 2),
+                new Instruction(VmOpcodes.OP_DUP_X1, 0),
+                new Instruction(VmOpcodes.OP_POP2, 0),
+                new Instruction(VmOpcodes.OP_PUSH, 3),
+                new Instruction(VmOpcodes.OP_HALT, 0)
+        };
+        long r = run(code, new long[0]);
+        assertEquals(3, r);
+
+        Instruction[] bad = new Instruction[]{
+                new Instruction(VmOpcodes.OP_POP, 0),
+                new Instruction(VmOpcodes.OP_HALT, 0)
+        };
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> run(bad, new long[0]));
+    }
+}


### PR DESCRIPTION
## Summary
- add POP/DUP family opcodes to micro VM
- handle stack manipulations for new opcodes and update translator
- add tests covering stack ops and underflow cases

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c5bfa5c6cc8332ba7d7ece116cd1fa