### PR TITLE
Add JVM stack manipulation opcodes and tests

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -223,6 +223,13 @@ public class VmTranslator {
         public static final int OP_IF_ICMPLE_W = 119;
         public static final int OP_IF_ICMPGT_W = 120;
         public static final int OP_IF_ICMPGE_W = 121;
+        public static final int OP_POP = 122;
+        public static final int OP_POP2 = 123;
+        public static final int OP_DUP_X1 = 124;
+        public static final int OP_DUP_X2 = 125;
+        public static final int OP_DUP2 = 126;
+        public static final int OP_DUP2_X1 = 127;
+        public static final int OP_DUP2_X2 = 128;
     }
 
     /**
@@ -253,6 +260,33 @@ public class VmTranslator {
         for (AbstractInsnNode insn = method.instructions.getFirst(); insn != null; insn = insn.getNext()) {
             int opcode = insn.getOpcode();
             switch (opcode) {
+                case Opcodes.POP:
+                    result.add(new Instruction(VmOpcodes.OP_POP, 0));
+                    break;
+                case Opcodes.POP2:
+                    result.add(new Instruction(VmOpcodes.OP_POP2, 0));
+                    break;
+                case Opcodes.DUP:
+                    result.add(new Instruction(VmOpcodes.OP_DUP, 0));
+                    break;
+                case Opcodes.DUP_X1:
+                    result.add(new Instruction(VmOpcodes.OP_DUP_X1, 0));
+                    break;
+                case Opcodes.DUP_X2:
+                    result.add(new Instruction(VmOpcodes.OP_DUP_X2, 0));
+                    break;
+                case Opcodes.DUP2:
+                    result.add(new Instruction(VmOpcodes.OP_DUP2, 0));
+                    break;
+                case Opcodes.DUP2_X1:
+                    result.add(new Instruction(VmOpcodes.OP_DUP2_X1, 0));
+                    break;
+                case Opcodes.DUP2_X2:
+                    result.add(new Instruction(VmOpcodes.OP_DUP2_X2, 0));
+                    break;
+                case Opcodes.SWAP:
+                    result.add(new Instruction(VmOpcodes.OP_SWAP, 0));
+                    break;
                 case Opcodes.ILOAD:
                     result.add(new Instruction(VmOpcodes.OP_LOAD, ((VarInsnNode) insn).var));
                     break;

--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -323,6 +323,13 @@ dispatch:
         case OP_JUNK2: goto do_junk2;
         case OP_SWAP:  goto do_swap;
         case OP_DUP:   goto do_dup;
+        case OP_POP:   goto do_pop;
+        case OP_POP2:  goto do_pop2;
+        case OP_DUP_X1: goto do_dup_x1;
+        case OP_DUP_X2: goto do_dup_x2;
+        case OP_DUP2:  goto do_dup2;
+        case OP_DUP2_X1: goto do_dup2_x1;
+        case OP_DUP2_X2: goto do_dup2_x2;
         case OP_LOAD:  goto do_load;
         case OP_LLOAD:
         case OP_FLOAD:
@@ -643,6 +650,78 @@ do_swap:
 
 do_dup:
     if (sp >= 1 && sp < 256) stack[sp++] = stack[sp - 1];
+    goto dispatch;
+
+do_pop:
+    if (sp >= 1) --sp;
+    goto dispatch;
+
+do_pop2:
+    if (sp >= 2) sp -= 2;
+    goto dispatch;
+
+do_dup_x1:
+    if (sp >= 2 && sp < 256) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        stack[sp] = v1;
+        stack[sp - 1] = v2;
+        stack[sp - 2] = v1;
+        ++sp;
+    }
+    goto dispatch;
+
+do_dup_x2:
+    if (sp >= 3 && sp < 256) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        int64_t v3 = stack[sp - 3];
+        stack[sp] = v1;
+        stack[sp - 1] = v2;
+        stack[sp - 2] = v3;
+        stack[sp - 3] = v1;
+        ++sp;
+    }
+    goto dispatch;
+
+do_dup2:
+    if (sp >= 2 && sp <= 254) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        stack[sp] = v2;
+        stack[sp + 1] = v1;
+        sp += 2;
+    }
+    goto dispatch;
+
+do_dup2_x1:
+    if (sp >= 3 && sp <= 254) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        int64_t v3 = stack[sp - 3];
+        stack[sp + 1] = v1;
+        stack[sp] = v2;
+        stack[sp - 1] = v3;
+        stack[sp - 2] = v1;
+        stack[sp - 3] = v2;
+        sp += 2;
+    }
+    goto dispatch;
+
+do_dup2_x2:
+    if (sp >= 4 && sp <= 254) {
+        int64_t v1 = stack[sp - 1];
+        int64_t v2 = stack[sp - 2];
+        int64_t v3 = stack[sp - 3];
+        int64_t v4 = stack[sp - 4];
+        stack[sp + 1] = v1;
+        stack[sp] = v2;
+        stack[sp - 1] = v3;
+        stack[sp - 2] = v4;
+        stack[sp - 3] = v1;
+        stack[sp - 4] = v2;
+        sp += 2;
+    }
     goto dispatch;
 
 do_load:

--- a/obfuscator/src/main/resources/sources/micro_vm.hpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.hpp
@@ -132,7 +132,14 @@ enum OpCode : uint8_t {
     OP_IF_ICMPLE_W = 119,  // wide int compare le
     OP_IF_ICMPGT_W = 120,  // wide int compare gt
     OP_IF_ICMPGE_W = 121,  // wide int compare ge
-    OP_COUNT = 122         // helper constant with number of opcodes
+    OP_POP   = 122,        // pop top stack value
+    OP_POP2  = 123,        // pop two top stack values
+    OP_DUP_X1 = 124,       // duplicate top and insert beneath one value
+    OP_DUP_X2 = 125,       // duplicate top and insert beneath two values
+    OP_DUP2  = 126,        // duplicate top two values
+    OP_DUP2_X1 = 127,      // duplicate top two and insert beneath one value
+    OP_DUP2_X2 = 128,      // duplicate top two and insert beneath two values
+    OP_COUNT = 129         // helper constant with number of opcodes
 };
 
 // Every field of an instruction is lightly encrypted and decoded at

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorStackOpsTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorStackOpsTest.java
@@ -1,0 +1,303 @@
+package by.radioegor146;
+
+import by.radioegor146.instructions.VmTranslator;
+import by.radioegor146.instructions.VmTranslator.Instruction;
+import by.radioegor146.instructions.VmTranslator.VmOpcodes;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for stack manipulation opcodes in {@link VmTranslator}.
+ */
+public class VmTranslatorStackOpsTest {
+
+    private long run(Instruction[] code) {
+        long[] stack = new long[256];
+        int sp = 0;
+        for (Instruction ins : code) {
+            switch (ins.opcode) {
+                case VmOpcodes.OP_PUSH:
+                    stack[sp++] = ins.operand;
+                    break;
+                case VmOpcodes.OP_ADD:
+                    if (sp >= 2) {
+                        stack[sp - 2] += stack[sp - 1];
+                        sp--;
+                    }
+                    break;
+                case VmOpcodes.OP_POP:
+                    if (sp >= 1) sp--;
+                    break;
+                case VmOpcodes.OP_POP2:
+                    if (sp >= 2) sp -= 2;
+                    break;
+                case VmOpcodes.OP_DUP:
+                    if (sp >= 1 && sp < 256) {
+                        long v = stack[sp - 1];
+                        stack[sp++] = v;
+                    }
+                    break;
+                case VmOpcodes.OP_DUP_X1:
+                    if (sp >= 2 && sp < 256) {
+                        long v1 = stack[sp - 1];
+                        long v2 = stack[sp - 2];
+                        stack[sp] = v1;
+                        stack[sp - 1] = v2;
+                        stack[sp - 2] = v1;
+                        sp++;
+                    }
+                    break;
+                case VmOpcodes.OP_DUP_X2:
+                    if (sp >= 3 && sp < 256) {
+                        long v1 = stack[sp - 1];
+                        long v2 = stack[sp - 2];
+                        long v3 = stack[sp - 3];
+                        stack[sp] = v1;
+                        stack[sp - 1] = v2;
+                        stack[sp - 2] = v3;
+                        stack[sp - 3] = v1;
+                        sp++;
+                    }
+                    break;
+                case VmOpcodes.OP_DUP2:
+                    if (sp >= 2 && sp <= 254) {
+                        long v1 = stack[sp - 1];
+                        long v2 = stack[sp - 2];
+                        stack[sp] = v2;
+                        stack[sp + 1] = v1;
+                        sp += 2;
+                    }
+                    break;
+                case VmOpcodes.OP_DUP2_X1:
+                    if (sp >= 3 && sp <= 254) {
+                        long v1 = stack[sp - 1];
+                        long v2 = stack[sp - 2];
+                        long v3 = stack[sp - 3];
+                        stack[sp + 1] = v1;
+                        stack[sp] = v2;
+                        stack[sp - 1] = v3;
+                        stack[sp - 2] = v1;
+                        stack[sp - 3] = v2;
+                        sp += 2;
+                    }
+                    break;
+                case VmOpcodes.OP_DUP2_X2:
+                    if (sp >= 4 && sp <= 254) {
+                        long v1 = stack[sp - 1];
+                        long v2 = stack[sp - 2];
+                        long v3 = stack[sp - 3];
+                        long v4 = stack[sp - 4];
+                        stack[sp + 1] = v1;
+                        stack[sp] = v2;
+                        stack[sp - 1] = v3;
+                        stack[sp - 2] = v4;
+                        stack[sp - 3] = v1;
+                        stack[sp - 4] = v2;
+                        sp += 2;
+                    }
+                    break;
+                case VmOpcodes.OP_SWAP:
+                    if (sp >= 2) {
+                        long t = stack[sp - 1];
+                        stack[sp - 1] = stack[sp - 2];
+                        stack[sp - 2] = t;
+                    }
+                    break;
+                case VmOpcodes.OP_HALT:
+                    return sp > 0 ? stack[sp - 1] : 0;
+            }
+        }
+        return sp > 0 ? stack[sp - 1] : 0;
+    }
+
+    private Instruction[] translate(MethodNode mn) {
+        VmTranslator translator = new VmTranslator();
+        return translator.translate(mn);
+    }
+
+    @Test
+    public void testPop() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.POP));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        Instruction[] code = translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_POP));
+        assertEquals(2, run(code));
+    }
+
+    @Test
+    public void testPop2() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.POP2));
+        il.add(new InsnNode(Opcodes.ICONST_3));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        Instruction[] code = translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_POP2));
+        assertEquals(3, run(code));
+    }
+
+    @Test
+    public void testDup() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.DUP));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        Instruction[] code = translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP));
+        assertEquals(2, run(code));
+    }
+
+    @Test
+    public void testDupX1() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.DUP_X1));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        Instruction[] code = translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP_X1));
+        assertEquals(5, run(code));
+    }
+
+    @Test
+    public void testDupX2() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.ICONST_3));
+        il.add(new InsnNode(Opcodes.DUP_X2));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        Instruction[] code = translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP_X2));
+        assertEquals(9, run(code));
+    }
+
+    @Test
+    public void testDup2() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.DUP2));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        Instruction[] code = translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2));
+        assertEquals(5, run(code));
+    }
+
+    @Test
+    public void testDup2X1() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.ICONST_3));
+        il.add(new InsnNode(Opcodes.DUP2_X1));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        Instruction[] code = translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2_X1));
+        assertEquals(11, run(code));
+    }
+
+    @Test
+    public void testDup2X2() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.ICONST_3));
+        il.add(new InsnNode(Opcodes.ICONST_4));
+        il.add(new InsnNode(Opcodes.DUP2_X2));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        Instruction[] code = translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2_X2));
+        assertEquals(17, run(code));
+    }
+
+    @Test
+    public void testSwap() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.ICONST_2));
+        il.add(new InsnNode(Opcodes.SWAP));
+        il.add(new InsnNode(Opcodes.IADD));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        Instruction[] code = translate(mn);
+        assertNotNull(code);
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_SWAP));
+        assertEquals(3, run(code));
+    }
+
+    @Test
+    public void testUnderflow() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "m", "()I", null, null);
+        InsnList il = mn.instructions;
+        il.add(new InsnNode(Opcodes.POP));
+        il.add(new InsnNode(Opcodes.POP2));
+        il.add(new InsnNode(Opcodes.DUP));
+        il.add(new InsnNode(Opcodes.DUP_X1));
+        il.add(new InsnNode(Opcodes.DUP_X2));
+        il.add(new InsnNode(Opcodes.DUP2));
+        il.add(new InsnNode(Opcodes.DUP2_X1));
+        il.add(new InsnNode(Opcodes.DUP2_X2));
+        il.add(new InsnNode(Opcodes.SWAP));
+        il.add(new InsnNode(Opcodes.ICONST_1));
+        il.add(new InsnNode(Opcodes.IRETURN));
+        Instruction[] code = translate(mn);
+        assertNotNull(code);
+        // ensure all opcodes are present
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_POP));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_POP2));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP_X1));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP_X2));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2_X1));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_DUP2_X2));
+        assertTrue(Arrays.stream(code).anyMatch(i -> i.opcode == VmOpcodes.OP_SWAP));
+        assertEquals(1, run(code));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add POP/POP2 and DUP* stack opcodes to micro VM
- support new opcodes in VmTranslator
- cover stack operations and underflow in unit tests

## Testing
- `./gradlew test --tests "by.radioegor146.VmTranslatorStackOpsTest"`
- `./gradlew test` *(partial, includes JavaObfuscatorTest)*

------
https://chatgpt.com/codex/tasks/task_e_68c63e7afc70833291c3103c4ec3f30b