### PR TITLE
Handle string and class constants in VM translator

### DIFF
--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorConstLoadTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorConstLoadTest.java
@@ -20,6 +20,8 @@ public class VmTranslatorConstLoadTest {
         static float floatLdc() { return 3.5f; }
         static double doubleConst() { return 1.0; }
         static double doubleLdc() { return 6.5; }
+        static String stringConst() { return "hello"; }
+        static Class<?> classConst() { return String.class; }
     }
 
     private Instruction[] translate(String name) throws Exception {
@@ -110,5 +112,31 @@ public class VmTranslatorConstLoadTest {
         Instruction[] code2 = translate("doubleLdc");
         assertEquals(VmOpcodes.OP_LDC2_W, code2[0].opcode);
         assertEquals(Double.doubleToLongBits(6.5), run(code2));
+    }
+
+    @Test
+    public void testStringConstant() throws Exception {
+        ClassReader cr = new ClassReader(ConstSamples.class.getName());
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+        MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("stringConst")).findFirst().orElseThrow();
+        VmTranslator translator = new VmTranslator();
+        Instruction[] code = translator.translate(mn);
+        assertNotNull(code);
+        assertEquals(VmOpcodes.OP_LDC, code[0].opcode);
+        assertEquals("hello", translator.getStringRefs().get(0));
+    }
+
+    @Test
+    public void testClassConstant() throws Exception {
+        ClassReader cr = new ClassReader(ConstSamples.class.getName());
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+        MethodNode mn = cn.methods.stream().filter(m -> m.name.equals("classConst")).findFirst().orElseThrow();
+        VmTranslator translator = new VmTranslator();
+        Instruction[] code = translator.translate(mn);
+        assertNotNull(code);
+        assertEquals(VmOpcodes.OP_LDC, code[0].opcode);
+        assertEquals("Ljava/lang/String;", translator.getLdcClassRefs().get(0));
     }
 }


### PR DESCRIPTION
## Summary
- detect `String` and `Type` constants in `VmTranslator` and track them for later patching
- patch string and class constants in generated C++ via `MethodProcessor`
- add regression tests for string and class `ldc` translation

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c66800f4a083328776e0be614023a2