### PR TITLE
Handle void RETURN in VM translator

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/VmTranslator.java
@@ -742,9 +742,11 @@ public class VmTranslator {
                 case Opcodes.LRETURN:
                 case Opcodes.FRETURN:
                 case Opcodes.DRETURN:
-                    result.add(new Instruction(VmOpcodes.OP_HALT, 0));
-                    break;
                 case Opcodes.ARETURN:
+                case Opcodes.RETURN:
+                    if (opcode == Opcodes.RETURN && frame != null && frame.getStackSize() != 0) {
+                        return null;
+                    }
                     result.add(new Instruction(VmOpcodes.OP_HALT, 0));
                     break;
                 case Opcodes.I2B:

--- a/obfuscator/src/test/java/by/radioegor146/VmTranslatorVoidReturnTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmTranslatorVoidReturnTest.java
@@ -1,0 +1,99 @@
+package by.radioegor146;
+
+import by.radioegor146.instructions.VmTranslator;
+import by.radioegor146.instructions.VmTranslator.Instruction;
+import by.radioegor146.instructions.VmTranslator.VmOpcodes;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Ensures that methods with void return types are correctly translated
+ * to a terminating {@link VmOpcodes#OP_HALT} instruction.
+ */
+public class VmTranslatorVoidReturnTest {
+
+    /** Sample class containing a void method. */
+    static class Sample {
+        static void store(int a, int b) {
+            int c = a + b;
+        }
+    }
+
+    /**
+     * Simple interpreter for a subset of VM instructions used by the test.
+     */
+    private long run(Instruction[] code, long[] locals) {
+        long[] stack = new long[256];
+        int sp = 0;
+        int pc = 0;
+        while (pc < code.length) {
+            Instruction ins = code[pc++];
+            switch (ins.opcode) {
+                case VmOpcodes.OP_PUSH:
+                    stack[sp++] = ins.operand;
+                    break;
+                case VmOpcodes.OP_LOAD:
+                    stack[sp++] = locals[(int) ins.operand];
+                    break;
+                case VmOpcodes.OP_STORE:
+                    locals[(int) ins.operand] = stack[--sp];
+                    break;
+                case VmOpcodes.OP_ADD:
+                    stack[sp - 2] += stack[sp - 1];
+                    sp--;
+                    break;
+                case VmOpcodes.OP_HALT:
+                    return sp > 0 ? stack[sp - 1] : 0;
+                default:
+                    throw new IllegalStateException("Unknown opcode: " + ins.opcode);
+            }
+        }
+        return sp > 0 ? stack[sp - 1] : 0;
+    }
+
+    @Test
+    public void testVoidMethodTranslation() throws Exception {
+        ClassReader cr = new ClassReader(Sample.class.getName());
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+        MethodNode mn = cn.methods.stream()
+                .filter(m -> m.name.equals("store"))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(mn);
+
+        VmTranslator translator = new VmTranslator();
+        Instruction[] code = translator.translate(mn);
+        assertNotNull(code);
+
+        // Ensure that the method terminates with OP_HALT
+        assertEquals(VmOpcodes.OP_HALT, code[code.length - 1].opcode);
+
+        long[] locals = new long[3];
+        locals[0] = 2;
+        locals[1] = 3;
+        long result = run(code, locals);
+
+        // Void method should not return a value but should store the sum
+        assertEquals(0, result);
+        assertEquals(locals[0] + locals[1], locals[2]);
+    }
+
+    @Test
+    public void testVoidMethodWithStackValue() {
+        MethodNode mn = new MethodNode(Opcodes.ACC_STATIC, "broken", "()V", null, null);
+        mn.visitInsn(Opcodes.ICONST_1);
+        mn.visitInsn(Opcodes.RETURN);
+        mn.visitMaxs(1, 0);
+        mn.visitEnd();
+
+        VmTranslator translator = new VmTranslator();
+        assertNull(translator.translate(mn));
+    }
+}
+


### PR DESCRIPTION
## Summary
- emit VM halt for void `RETURN` while checking for non-empty stacks
- add regression test for void method with stray stack entries

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c665e63ce0833284bfae35ef14ee9c