### PR TITLE
Prevent state encoder arithmetic from being optimized away

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/ControlFlowFlattener.java
+++ b/obfuscator/src/main/java/by/radioegor146/ControlFlowFlattener.java
@@ -1,6 +1,11 @@
 package by.radioegor146;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Control flow flattening utility for native code generation.
@@ -9,27 +14,193 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 public class ControlFlowFlattener {
 
+    private static final Pattern STATE_ASSIGNMENT_PATTERN = Pattern.compile("__ngen_state\\s*=\\s*(-?\\d+)");
+
     /**
-     * Generates a flattened switch-case structure around the provided code block.
-     * The code is wrapped in a randomized state machine that executes the actual logic.
-     *
-     * @param originalCode The original code to be flattened
-     * @param methodName The name of the method (used for unique state generation)
-     * @return The flattened code wrapped in obfuscated control flow
+     * Strategy factory used to produce control-flow state encoders.
+     * External users can provide their own implementations to leverage
+     * custom hardware instructions or domain-specific mixing functions.
      */
+    public interface StateObfuscationStrategy {
+        StateObfuscation create(String methodName);
+    }
+
+    /**
+     * Encapsulates the logic required to encode raw control-flow states into
+     * the obfuscated representation used inside the generated switch statement.
+     */
+    public interface StateObfuscation {
+        void appendPrologue(StringBuilder out, String indent);
+
+        int encodeCase(int rawState);
+
+        String generateEncodeExpression(int rawState);
+
+        default void appendStateAssignment(StringBuilder out, String indent, String stateVarName, int rawState) {
+            out.append(indent)
+               .append(stateVarName)
+               .append(" = ")
+               .append(generateEncodeExpression(rawState))
+               .append(";\n");
+        }
+    }
+
+    private static final class DefaultStateObfuscationStrategy implements StateObfuscationStrategy {
+        @Override
+        public StateObfuscation create(String methodName) {
+            return new DefaultStateObfuscation();
+        }
+    }
+
+    private static final class DefaultStateObfuscation implements StateObfuscation {
+        private final int xorMask;
+        private final int multiplier;
+        private final int bias;
+        private final int rotation;
+
+        private DefaultStateObfuscation() {
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            this.xorMask = random.nextInt();
+            int candidate;
+            do {
+                candidate = random.nextInt();
+            } while ((candidate & 1) == 0);
+            this.multiplier = candidate;
+            this.bias = random.nextInt();
+            this.rotation = 1 + random.nextInt(31);
+        }
+
+        @Override
+        public void appendPrologue(StringBuilder out, String indent) {
+            out.append(indent)
+                    .append("alignas(16) static volatile jint __ngen_state_params[4] = { ")
+                    .append(String.format("static_cast<jint>(0x%08X)", xorMask)).append(", ")
+                    .append(String.format("static_cast<jint>(0x%08X)", multiplier)).append(", ")
+                    .append(String.format("static_cast<jint>(0x%08X)", bias)).append(", ")
+                    .append(rotation)
+                    .append(" };\n");
+            out.append(indent).append("auto __ngen_encode_state = [&](int __ngen_raw_state) -> int {\n");
+            out.append(indent).append("    volatile const jint* __ngen_params = __ngen_state_params;\n");
+            out.append(indent).append("    uint32_t __ngen_val = static_cast<uint32_t>(__ngen_raw_state);\n");
+            out.append(indent).append("    uint32_t __ngen_mul = static_cast<uint32_t>(__ngen_params[1]);\n");
+            out.append(indent).append("    uint32_t __ngen_mask = static_cast<uint32_t>(__ngen_params[0]);\n");
+            out.append(indent).append("    uint32_t __ngen_bias = static_cast<uint32_t>(__ngen_params[2]);\n");
+            out.append(indent).append("    uint32_t __ngen_rot = static_cast<uint32_t>(__ngen_params[3]) & 31U;\n");
+            out.append(indent).append("    __ngen_val = (__ngen_val * __ngen_mul) ^ __ngen_mask;\n");
+            out.append(indent).append("    uint32_t __ngen_left = __ngen_val << __ngen_rot;\n");
+            out.append(indent).append("    uint32_t __ngen_right = (__ngen_rot == 0U) ? __ngen_val : (__ngen_val >> (32U - __ngen_rot));\n");
+            out.append(indent).append("    __ngen_val = (__ngen_left | __ngen_right) ^ __ngen_bias;\n");
+            out.append(indent).append("    return static_cast<int>(__ngen_val);\n");
+            out.append(indent).append("};\n");
+        }
+
+        @Override
+        public int encodeCase(int rawState) {
+            return encodeInternal(rawState);
+        }
+
+        @Override
+        public String generateEncodeExpression(int rawState) {
+            return "__ngen_encode_state(" + rawState + ")";
+        }
+
+        private int encodeInternal(int rawState) {
+            long value = Integer.toUnsignedLong(rawState);
+            long mul = Integer.toUnsignedLong(multiplier);
+            long mask = Integer.toUnsignedLong(xorMask);
+            long biasValue = Integer.toUnsignedLong(bias);
+            value = (value * mul) & 0xFFFFFFFFL;
+            value ^= mask;
+            int rotated = Integer.rotateLeft((int) value, rotation);
+            long result = Integer.toUnsignedLong(rotated) ^ biasValue;
+            return (int) result;
+        }
+    }
+
+    private static volatile StateObfuscationStrategy stateObfuscationStrategy = new DefaultStateObfuscationStrategy();
+
+    public static void setStateObfuscationStrategy(StateObfuscationStrategy strategy) {
+        stateObfuscationStrategy = Objects.requireNonNull(strategy, "strategy");
+    }
+
+    public static StateObfuscation createObfuscation(String methodName) {
+        return stateObfuscationStrategy.create(methodName);
+    }
+
+    public static void appendStateTransition(StringBuilder out, String indent, String stateVarName,
+                                             int rawState, StateObfuscation obfuscation) {
+        Objects.requireNonNull(obfuscation, "obfuscation");
+        obfuscation.appendStateAssignment(out, indent, stateVarName, rawState);
+        out.append(indent).append("break;\n");
+    }
+
+    public static String obfuscateStateAssignments(String code, StateObfuscation obfuscation) {
+        if (code == null || code.isEmpty() || obfuscation == null) {
+            return code;
+        }
+        Matcher matcher = STATE_ASSIGNMENT_PATTERN.matcher(code);
+        StringBuffer result = new StringBuffer();
+        while (matcher.find()) {
+            int rawState = Integer.parseInt(matcher.group(1));
+            String replacement = "__ngen_state = " + obfuscation.generateEncodeExpression(rawState);
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    public static String generateStateMachine(String methodName, String returnType, int initialState,
+                                              Map<Integer, StringBuilder> stateBlocks,
+                                              String defaultBlock,
+                                              StateObfuscation obfuscation) {
+        if (stateBlocks == null || stateBlocks.isEmpty()) {
+            return "";
+        }
+        StateObfuscation stateObfuscation = obfuscation != null ? obfuscation : createObfuscation(methodName);
+        StringBuilder flattened = new StringBuilder();
+        stateObfuscation.appendPrologue(flattened, "    ");
+        flattened.append("    volatile int __ngen_state = ")
+                .append(stateObfuscation.generateEncodeExpression(initialState))
+                .append(";\n");
+        flattened.append("    while (true) {\n");
+        flattened.append("        switch (__ngen_state) {\n");
+
+        for (Map.Entry<Integer, StringBuilder> entry : stateBlocks.entrySet()) {
+            flattened.append("        case ")
+                    .append(stateObfuscation.encodeCase(entry.getKey()))
+                    .append(": {\n");
+            String block = entry.getValue().toString();
+            if (!block.isEmpty()) {
+                flattened.append(block);
+                if (block.charAt(block.length() - 1) != '\n') {
+                    flattened.append('\n');
+                }
+            }
+            flattened.append("        }\n");
+        }
+
+        if (defaultBlock != null && !defaultBlock.isEmpty()) {
+            flattened.append("        default: {\n");
+            flattened.append(defaultBlock);
+            if (!defaultBlock.endsWith("\n")) {
+                flattened.append('\n');
+            }
+            flattened.append("        }\n");
+        } else {
+            flattened.append("        default: {\n");
+            flattened.append("            break;\n");
+            flattened.append("        }\n");
+        }
+
+        flattened.append("        }\n");
+        flattened.append("    }\n\n");
+        return flattened.toString();
+    }
+
     public static String flattenControlFlow(String originalCode, String methodName) {
         return flattenControlFlow(originalCode, methodName, "void");
     }
 
-    /**
-     * Generates a flattened switch-case structure around the provided code block.
-     * The code is wrapped in a randomized state machine that executes the actual logic.
-     *
-     * @param originalCode The original code to be flattened
-     * @param methodName The name of the method (used for unique state generation)
-     * @param returnType The return type of the method (for generating proper fallback return statement)
-     * @return The flattened code wrapped in obfuscated control flow
-     */
     public static String flattenControlFlow(String originalCode, String methodName, String returnType) {
         if (originalCode == null || originalCode.trim().isEmpty()) {
             return originalCode;
@@ -39,53 +210,46 @@ public class ControlFlowFlattener {
         int realState = generateStateId(methodName, seed);
         int[] dummyStates = generateDummyStates(realState, 3 + ThreadLocalRandom.current().nextInt(5));
 
+        StateObfuscation stateObfuscation = createObfuscation(methodName);
         StringBuilder flattened = new StringBuilder();
-
-        // Generate state variable initialization with obfuscation
-        flattened.append(String.format("    volatile int __ngen_state = %d ^ 0x%08X;\n",
-                realState ^ 0x12345678, 0x12345678));
+        stateObfuscation.appendPrologue(flattened, "    ");
+        flattened.append("    volatile int __ngen_state = ")
+                .append(stateObfuscation.generateEncodeExpression(realState))
+                .append(";\n");
         flattened.append("    volatile bool __ngen_flow_continue = true;\n");
 
-        // Start the flattened control flow
         flattened.append("    while (__ngen_flow_continue) {\n");
         flattened.append("        switch (__ngen_state) {\n");
 
-        // Add the real case with the original code
-        flattened.append(String.format("        case %d: {\n", realState));
+        flattened.append("        case ")
+                .append(stateObfuscation.encodeCase(realState))
+                .append(": {\n");
         flattened.append("            // Real execution path\n");
-
-        // Indent the original code properly
         String[] lines = originalCode.split("\n");
         for (String line : lines) {
             flattened.append("            ").append(line).append("\n");
         }
-
         flattened.append("            __ngen_flow_continue = false;\n");
         flattened.append("            break;\n");
         flattened.append("        }\n");
 
-        // Add dummy cases for obfuscation
         for (int dummyState : dummyStates) {
-            flattened.append(String.format("        case %d: {\n", dummyState));
+            flattened.append("        case ")
+                    .append(stateObfuscation.encodeCase(dummyState))
+                    .append(": {\n");
             flattened.append("            // Dummy path - never executed\n");
             flattened.append(generateDummyCode());
-            flattened.append("            __ngen_state = ").append(realState).append(";\n");
-            flattened.append("            break;\n");
+            appendStateTransition(flattened, "            ", "__ngen_state", realState, stateObfuscation);
             flattened.append("        }\n");
         }
 
-        // Default case
         flattened.append("        default: {\n");
-        flattened.append("            // Fallback to real execution\n");
-        flattened.append("            __ngen_state = ").append(realState).append(";\n");
-        flattened.append("            break;\n");
+        appendStateTransition(flattened, "            ", "__ngen_state", realState, stateObfuscation);
         flattened.append("        }\n");
 
-        flattened.append("        }\n"); // End switch
-        flattened.append("    }\n");     // End while
+        flattened.append("        }\n");
+        flattened.append("    }\n");
 
-        // Add unreachable return statement to satisfy MSVC C4715 warning
-        // This code should never be reached but prevents compiler warning
         if (!"void".equals(returnType)) {
             flattened.append("    // Unreachable fallback return to prevent C4715 warning\n");
             flattened.append("    return ");
@@ -96,16 +260,10 @@ public class ControlFlowFlattener {
         return flattened.toString();
     }
 
-    /**
-     * Generates a unique state ID based on method name and seed.
-     */
     private static int generateStateId(String methodName, long seed) {
-        return Math.abs((methodName.hashCode() ^ (int)seed) % 1000000) + 1000;
+        return Math.abs((methodName.hashCode() ^ (int) seed) % 1000000) + 1000;
     }
 
-    /**
-     * Generates dummy state IDs that are different from the real state.
-     */
     private static int[] generateDummyStates(int realState, int count) {
         int[] dummyStates = new int[count];
         for (int i = 0; i < count; i++) {
@@ -116,19 +274,14 @@ public class ControlFlowFlattener {
         return dummyStates;
     }
 
-    /**
-     * Generates dummy C++ code that does not affect the execution but adds complexity.
-     */
     private static String generateDummyCode() {
         StringBuilder dummy = new StringBuilder();
 
-        // Always declare the variables first to avoid undeclared variable errors
         dummy.append("            volatile int __dummy = 0x")
              .append(Integer.toHexString(ThreadLocalRandom.current().nextInt()))
              .append(";\n");
         dummy.append("            volatile jlong __temp = 0;\n");
 
-        // Generate random dummy operations that use these variables
         String[] dummyOperations = {
             "            __temp = (jlong)(__dummy ^ 0xDEADBEEF);\n",
             "            __dummy = (int)(__temp & 0xFFFFFFFF);\n",
@@ -144,16 +297,11 @@ public class ControlFlowFlattener {
         return dummy.toString();
     }
 
-    /**
-     * Gets the default return value for a given return type to prevent C4715 warnings.
-     * This return statement should never be reached but satisfies the compiler.
-     */
     private static String getDefaultReturnValue(String returnType) {
         if (returnType == null || returnType.trim().isEmpty() || "void".equals(returnType)) {
             return "";
         }
 
-        // Handle C++ return types commonly used in JNI
         switch (returnType.toLowerCase().trim()) {
             case "jint":
             case "jlong":
@@ -182,20 +330,14 @@ public class ControlFlowFlattener {
             case "jthrowable":
                 return "nullptr";
             default:
-                // For pointer types or complex types, return nullptr
                 if (returnType.contains("*") || returnType.startsWith("j")) {
                     return "nullptr";
                 }
-                // For other types, try to return zero-initialized value
                 return "{}";
         }
     }
 
-    /**
-     * Applies basic obfuscation to variable names in the code.
-     */
     public static String obfuscateVariableNames(String code) {
-        // Simple variable name obfuscation - replace common patterns
         return code
             .replaceAll("\\btemp\\b", "__ngen_tmp_" + ThreadLocalRandom.current().nextInt(1000))
             .replaceAll("\\bindex\\b", "__ngen_idx_" + ThreadLocalRandom.current().nextInt(1000))

--- a/obfuscator/src/main/java/by/radioegor146/MethodContext.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodContext.java
@@ -20,6 +20,13 @@ public class MethodContext {
     public final StringBuilder output;
     public final StringBuilder nativeMethods;
 
+    /**
+     * Strategy used to encode/decode control-flow states for the currently processed method.
+     * This is populated by {@link MethodProcessor} when control-flow flattening is active so that
+     * instruction handlers can emit state updates through the shared {@link ControlFlowFlattener} logic.
+     */
+    public ControlFlowFlattener.StateObfuscation stateObfuscation;
+
     public Type ret;
     public ArrayList<Type> argTypes;
 
@@ -100,5 +107,14 @@ public class MethodContext {
 
     public LabelPool getLabelPool() {
         return labelPool;
+    }
+
+    public String getSnippet(String key) {
+        return getSnippet(key, Util.createMap());
+    }
+
+    public String getSnippet(String key, Map<String, String> tokens) {
+        String snippet = obfuscator.getSnippets().getSnippet(key, tokens);
+        return ControlFlowFlattener.obfuscateStateAssignments(snippet, stateObfuscation);
     }
 }

--- a/obfuscator/src/main/java/by/radioegor146/instructions/LookupSwitchHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/LookupSwitchHandler.java
@@ -25,20 +25,20 @@ public class LookupSwitchHandler extends GenericInstructionHandler<LookupSwitchI
     }
 
     private static String getStart(MethodContext context) {
-        return context.getSnippets().getSnippet("LOOKUPSWITCH_START", Util.createMap(
+        return context.getSnippet("LOOKUPSWITCH_START", Util.createMap(
                 "stackindexm1", String.valueOf(context.stackPointer - 1)
         ));
     }
 
     private static String getPart(MethodContext context, int key, Label label) {
-        return context.getSnippets().getSnippet("LOOKUPSWITCH_PART", Util.createMap(
+        return context.getSnippet("LOOKUPSWITCH_PART", Util.createMap(
                 "key", key,
                 "label", context.getLabelPool().getName(label)
         ));
     }
 
     private static String getDefault(MethodContext context, Label label) {
-        return context.getSnippets().getSnippet("LOOKUPSWITCH_DEFAULT", Util.createMap(
+        return context.getSnippet("LOOKUPSWITCH_DEFAULT", Util.createMap(
                 "label", context.getLabelPool().getName(label)
         ));
     }

--- a/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
@@ -66,7 +66,7 @@ public class MethodHandler extends GenericInstructionHandler<MethodInsnNode> {
             }
 
             for (int i = 0; i < argOffsets.size(); i++) {
-                argsBuilder.append(", ").append(context.getSnippets().getSnippet("INVOKE_ARG_" + args[i].getSort(),
+                argsBuilder.append(", ").append(context.getSnippet("INVOKE_ARG_" + args[i].getSort(),
                         Util.createMap("index", argOffsets.get(i))));
             }
 
@@ -169,7 +169,7 @@ public class MethodHandler extends GenericInstructionHandler<MethodInsnNode> {
         int objectOffset = isStatic ? 0 : 1;
 
         for (int i = 0; i < argOffsets.size(); i++) {
-            argsBuilder.append(", ").append(context.getSnippets().getSnippet("INVOKE_ARG_" + args[i].getSort(),
+            argsBuilder.append(", ").append(context.getSnippet("INVOKE_ARG_" + args[i].getSort(),
                     Util.createMap("index", argOffsets.get(i))));
         }
 

--- a/obfuscator/src/main/java/by/radioegor146/instructions/TableSwitchHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/TableSwitchHandler.java
@@ -25,20 +25,20 @@ public class TableSwitchHandler extends GenericInstructionHandler<TableSwitchIns
     }
 
     private static String getStart(MethodContext context) {
-        return context.getSnippets().getSnippet("TABLESWITCH_START", Util.createMap(
+        return context.getSnippet("TABLESWITCH_START", Util.createMap(
                 "stackindexm1", String.valueOf(context.stackPointer - 1)
         ));
     }
 
     private static String getPart(MethodContext context, int index, Label label) {
-        return context.getSnippets().getSnippet("TABLESWITCH_PART", Util.createMap(
+        return context.getSnippet("TABLESWITCH_PART", Util.createMap(
                 "index", index,
                 "label", context.getLabelPool().getName(label)
         ));
     }
 
     private static String getDefault(MethodContext context, Label label) {
-        return context.getSnippets().getSnippet("TABLESWITCH_DEFAULT", Util.createMap(
+        return context.getSnippet("TABLESWITCH_DEFAULT", Util.createMap(
                 "label", context.getLabelPool().getName(label)
         ));
     }

--- a/obfuscator/src/test/java/by/radioegor146/ClassicTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/ClassicTest.java
@@ -149,7 +149,7 @@ public class ClassicTest implements Executable {
                 Path resultJar = tempOutput.resolve("test.jar");
 
                 new NativeObfuscator().process(idealJar, tempOutput, Collections.emptyList(), Collections.emptyList(),
-                        null, "native_library", null, platform, true, true);
+                        null, "native_library", null, platform, true, true, true, true, true);
 
                 System.out.println("Compiling CPP code...");
                 if (System.getProperty("os.name").toLowerCase().contains("windows")) {

--- a/obfuscator/src/test/java/by/radioegor146/VmFieldPipelineTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmFieldPipelineTest.java
@@ -50,7 +50,7 @@ public class VmFieldPipelineTest {
 
         new NativeObfuscator().process(inputJar, out, Collections.emptyList(),
                 Collections.singletonList("Main"), null, "native_library", null,
-                Platform.HOTSPOT, true, false);
+                Platform.HOTSPOT, true, false, true, true, true);
 
         Path cppDir = out.resolve("cpp");
         ProcessHelper.run(cppDir, 120_000, Arrays.asList("cmake", "."))

--- a/obfuscator/src/test/java/by/radioegor146/VmGetPutFieldPipelineTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/VmGetPutFieldPipelineTest.java
@@ -60,7 +60,7 @@ public class VmGetPutFieldPipelineTest {
 
         new NativeObfuscator().process(inputJar, out, Collections.emptyList(),
                 Collections.emptyList(), null, "native_library", null,
-                Platform.HOTSPOT, false, false);
+                Platform.HOTSPOT, false, false, true, true, true);
 
         Path cppDir = out.resolve("cpp");
         ProcessHelper.run(cppDir, 120_000, Arrays.asList("cmake", "."))


### PR DESCRIPTION
## Summary
- store the default control-flow state encoder constants inside a volatile parameter block so the generated native code must load them at runtime
- rebuild the encoder lambda to consume the volatile parameters with rotate-and-xor mixing so compilers cannot fold state transitions into raw constants while preserving compatibility with custom obfuscation strategies

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ca04ffb3e883328ce47c669c770b9f