### PR TITLE
Avoid executing VM JIT on unsupported bytecode

### DIFF
--- a/obfuscator/src/main/resources/sources/micro_vm.cpp
+++ b/obfuscator/src/main/resources/sources/micro_vm.cpp
@@ -2130,13 +2130,31 @@ int64_t execute_jit(JNIEnv* env, const Instruction* code, size_t length,
     ensure_init(seed);
     auto it = jit_cache.find(code);
     if (it != jit_cache.end()) {
-        return it->second.func(env, locals, locals_length, seed, it->second.ctx);
+        if (it->second.func != nullptr) {
+            return it->second.func(env, locals, locals_length, seed, it->second.ctx);
+        }
+        return execute(env, code, length, locals, locals_length, seed,
+                       constant_pool, constant_pool_size,
+                       method_refs, method_refs_size,
+                       field_refs, field_refs_size,
+                       multi_refs, multi_refs_size,
+                       table_refs, table_refs_size,
+                       lookup_refs, lookup_refs_size);
     }
     size_t& cnt = exec_counts[code];
     if (++cnt > HOT_THRESHOLD) {
         JitCompiled compiled = compile(code, length, seed);
         it = jit_cache.emplace(code, compiled).first;
-        return it->second.func(env, locals, locals_length, seed, it->second.ctx);
+        if (it->second.func != nullptr) {
+            return it->second.func(env, locals, locals_length, seed, it->second.ctx);
+        }
+        return execute(env, code, length, locals, locals_length, seed,
+                       constant_pool, constant_pool_size,
+                       method_refs, method_refs_size,
+                       field_refs, field_refs_size,
+                       multi_refs, multi_refs_size,
+                       table_refs, table_refs_size,
+                       lookup_refs, lookup_refs_size);
     }
     return execute(env, code, length, locals, locals_length, seed, constant_pool, constant_pool_size, method_refs, method_refs_size, field_refs, field_refs_size, multi_refs, multi_refs_size, table_refs, table_refs_size, lookup_refs, lookup_refs_size);
 }

--- a/obfuscator/src/main/resources/sources/vm_jit.cpp
+++ b/obfuscator/src/main/resources/sources/vm_jit.cpp
@@ -8,6 +8,97 @@ struct Program {
     std::vector<DecodedInstruction> ins;
 };
 
+static bool is_supported_for_jit(OpCode op) {
+    switch (op) {
+        case OP_PUSH:
+        case OP_LDC:
+        case OP_LDC_W:
+        case OP_LDC2_W:
+        case OP_ADD:
+        case OP_SUB:
+        case OP_MUL:
+        case OP_DIV:
+        case OP_PRINT:
+        case OP_NOP:
+        case OP_JUNK1:
+        case OP_JUNK2:
+        case OP_SWAP:
+        case OP_DUP:
+        case OP_DUP_X1:
+        case OP_DUP_X2:
+        case OP_DUP2:
+        case OP_DUP2_X1:
+        case OP_DUP2_X2:
+        case OP_ATHROW:
+        case OP_TRY_START:
+        case OP_CATCH_HANDLER:
+        case OP_FINALLY_HANDLER:
+        case OP_EXCEPTION_CHECK:
+        case OP_EXCEPTION_CLEAR:
+        case OP_LOAD:
+        case OP_LLOAD:
+        case OP_FLOAD:
+        case OP_DLOAD:
+        case OP_STORE:
+        case OP_LSTORE:
+        case OP_FSTORE:
+        case OP_DSTORE:
+        case OP_IF_ICMPEQ:
+        case OP_IF_ICMPNE:
+        case OP_GOTO:
+        case OP_AND:
+        case OP_OR:
+        case OP_XOR:
+        case OP_SHL:
+        case OP_SHR:
+        case OP_USHR:
+        case OP_IF_ICMPLT:
+        case OP_IF_ICMPLE:
+        case OP_IF_ICMPGT:
+        case OP_IF_ICMPGE:
+        case OP_I2L:
+        case OP_I2B:
+        case OP_I2C:
+        case OP_I2S:
+        case OP_I2F:
+        case OP_I2D:
+        case OP_L2I:
+        case OP_L2F:
+        case OP_L2D:
+        case OP_F2I:
+        case OP_F2L:
+        case OP_F2D:
+        case OP_D2I:
+        case OP_D2L:
+        case OP_D2F:
+        case OP_NEG:
+        case OP_ALOAD:
+        case OP_ASTORE:
+        case OP_AALOAD:
+        case OP_AASTORE:
+        case OP_IALOAD:
+        case OP_BALOAD:
+        case OP_CALOAD:
+        case OP_SALOAD:
+        case OP_IASTORE:
+        case OP_BASTORE:
+        case OP_CASTORE:
+        case OP_SASTORE:
+        case OP_INVOKESTATIC:
+        case OP_FCONST_0:
+        case OP_FCONST_1:
+        case OP_FCONST_2:
+        case OP_DCONST_0:
+        case OP_DCONST_1:
+        case OP_LCONST_0:
+        case OP_LCONST_1:
+        case OP_HALT:
+            return true;
+        default:
+            return false;
+    }
+}
+
 static int64_t run_program(JNIEnv* env, int64_t* locals, size_t locals_len,
                            uint64_t /*seed*/, void* ctx) {
     auto* prog = reinterpret_cast<Program*>(ctx);
@@ -452,6 +543,12 @@ static int64_t run_program(JNIEnv* env, int64_t* locals, size_t locals_len,
 JitCompiled compile(const Instruction* code, size_t length, uint64_t seed) {
     auto* prog = new Program();
     decode_for_jit(code, length, seed, prog->ins);
+    for (const auto& ins : prog->ins) {
+        if (!is_supported_for_jit(ins.op)) {
+            delete prog;
+            return {};
+        }
+    }
     return { run_program, prog };
 }
 


### PR DESCRIPTION
## Summary
- ensure the VM JIT cache falls back to the interpreter when a compiled stub is unavailable so virtualized methods preserve semantics
- gate JIT compilation behind an opcode support check and bail out when a method uses instructions the lightweight JIT does not emulate

## Testing
- ./gradlew build --console=plain
- java -jar /workspace/native-obfuscator/obfuscator/build/libs/obfuscator.jar --enable-virtualization --enable-jit /tmp/Snake/SnakeGame.jar /workspace/native-obfuscator/runs/snake-test
- (cd /workspace/native-obfuscator/runs/snake-test/cpp && cmake . && cmake --build . --config Release -j)


------
https://chatgpt.com/codex/tasks/task_e_68caa76774d883328e250e216c477a48