### PR TITLE
Adjust UI hints and copy

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/ui/ObfuscatorFrame.java
+++ b/obfuscator/src/main/java/by/radioegor146/ui/ObfuscatorFrame.java
@@ -29,9 +29,6 @@ public class ObfuscatorFrame extends JFrame {
     private static final int LABEL_W = 180;
     private static final int FIELD_H = 30;
     private static final int BROWSE_W = 96;   // fixed column width for Browse
-    private static final int HINT_MIN_W = 96;
-    private static final int HINT_MAX_W = 360;
-    private static final int HINT_PADDING = 12;
     private static final int ROW_H = 40;      // max row height for single-line rows
 
     // LEFT NAV SECTIONS
@@ -48,15 +45,15 @@ public class ObfuscatorFrame extends JFrame {
     private final JTextField plainLibNameField = new JTextField();
     private final JTextField customLibDirField = new JTextField();
     private final JComboBox<Platform> platformCombo = new JComboBox<>(Platform.values());
-    private final JCheckBox useAnnotationsBox = new JCheckBox("📝 Use annotations");
-    private final JCheckBox debugJarBox = new JCheckBox("🐛 Generate debug jar");
-    private final JCheckBox packageBox = new JCheckBox("📦 Package native lib into JAR", true);
+    private final JCheckBox useAnnotationsBox = new JCheckBox("Use annotations");
+    private final JCheckBox debugJarBox = new JCheckBox("Generate debug jar");
+    private final JCheckBox packageBox = new JCheckBox("Package native library into JAR", true);
 
     // Protection feature checkboxes
-    private final JCheckBox enableVirtualizationBox = new JCheckBox("🖥️ Enable VM virtualization");
-    private final JCheckBox enableJitBox = new JCheckBox("⚡ Enable JIT compilation");
-    private final JCheckBox flattenControlFlowBox = new JCheckBox("🌀 Enable control flow flattening");
-    private final JButton runButton = new JButton("▶️ Run Obfuscation");
+    private final JCheckBox enableVirtualizationBox = new JCheckBox("Enable VM virtualization");
+    private final JCheckBox enableJitBox = new JCheckBox("Enable JIT compilation");
+    private final JCheckBox flattenControlFlowBox = new JCheckBox("Enable control flow flattening");
+    private final JButton runButton = new JButton("Run obfuscation");
     private final JTextArea logArea = new JTextArea();
     private final JProgressBar progressBar = new JProgressBar();
 
@@ -126,13 +123,13 @@ public class ObfuscatorFrame extends JFrame {
         });
 
         // Placeholders (FlatLaf)
-        jarField.putClientProperty("JTextComponent.placeholderText", "📦 Select input .jar");
-        outDirField.putClientProperty("JTextComponent.placeholderText", "📁 Choose output directory");
-        libsDirField.putClientProperty("JTextComponent.placeholderText", "📂 Optional libraries directory");
-        whitelistField.putClientProperty("JTextComponent.placeholderText", "✅ Optional whitelist.txt");
-        blacklistField.putClientProperty("JTextComponent.placeholderText", "❌ Optional blacklist.txt");
-        plainLibNameField.putClientProperty("JTextComponent.placeholderText", "📝 Specify to skip packaging");
-        customLibDirField.putClientProperty("JTextComponent.placeholderText", "📁 e.g. native/win64 — inside output JAR");
+        jarField.putClientProperty("JTextComponent.placeholderText", "Select input .jar");
+        outDirField.putClientProperty("JTextComponent.placeholderText", "Choose output directory");
+        libsDirField.putClientProperty("JTextComponent.placeholderText", "Optional libraries directory");
+        whitelistField.putClientProperty("JTextComponent.placeholderText", "Optional whitelist.txt");
+        blacklistField.putClientProperty("JTextComponent.placeholderText", "Optional blacklist.txt");
+        plainLibNameField.putClientProperty("JTextComponent.placeholderText", "Specify to skip packaging");
+        customLibDirField.putClientProperty("JTextComponent.placeholderText", "Example: native/win64 inside output JAR");
     }
 
     // ------------------------ ICON CREATION ------------------------
@@ -176,9 +173,9 @@ public class ObfuscatorFrame extends JFrame {
 
     private JList<String> buildLeftNav() {
         DefaultListModel<String> model = new DefaultListModel<>();
-        model.addElement("📁 Import Files");
-        model.addElement("⚙️ Native Settings");
-        model.addElement("🚀 Run & Logs");
+        model.addElement("Import files");
+        model.addElement("Native settings");
+        model.addElement("Run & logs");
 
         final JList<String> list = new JList<>(model);
         list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -216,23 +213,23 @@ public class ObfuscatorFrame extends JFrame {
         JPanel form = new JPanel();
         form.setLayout(new BoxLayout(form, BoxLayout.Y_AXIS));
 
-        form.add(createPathRowPanel("📦 Input JAR", jarField, this::browseFileJar,
+        form.add(createPathRowPanel("Input JAR", jarField, this::browseFileJar,
                 "Select the Java archive to obfuscate"));
         form.add(Box.createRigidArea(new Dimension(0, 8)));
 
-        form.add(createPathRowPanel("📁 Output Directory", outDirField, this::browseDir,
+        form.add(createPathRowPanel("Output directory", outDirField, this::browseDir,
                 "Destination folder for obfuscated files"));
         form.add(Box.createRigidArea(new Dimension(0, 8)));
 
-        form.add(createPathRowPanel("📂 Libraries Directory", libsDirField, this::browseDirOptional,
+        form.add(createPathRowPanel("Libraries directory", libsDirField, this::browseDirOptional,
                 "Additional JAR/ZIP dependencies"));
         form.add(Box.createRigidArea(new Dimension(0, 8)));
 
-        form.add(createPathRowPanel("❌ Blacklist File", blacklistField, () -> browseFileTxt(blacklistField),
+        form.add(createPathRowPanel("Blacklist file", blacklistField, () -> browseFileTxt(blacklistField),
                 "Exclude classes/packages from obfuscation"));
         form.add(Box.createRigidArea(new Dimension(0, 8)));
 
-        form.add(createPathRowPanel("✅ Whitelist File", whitelistField, () -> browseFileTxt(whitelistField),
+        form.add(createPathRowPanel("Whitelist file", whitelistField, () -> browseFileTxt(whitelistField),
                 "Allow-only list; overrides blacklist"));
 
 
@@ -242,7 +239,7 @@ public class ObfuscatorFrame extends JFrame {
         card.add(form, BorderLayout.CENTER);
 
         JPanel footer = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        JButton next = new JButton("Next → Settings ⚙️");
+        JButton next = new JButton("Next → Settings");
         next.addActionListener(e -> { leftNav.setSelectedIndex(1); showCard(CARD_SETTINGS); });
         footer.add(next);
         card.add(footer, BorderLayout.SOUTH);
@@ -263,11 +260,11 @@ public class ObfuscatorFrame extends JFrame {
         upperHintsScope.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         // Plain Library Name
-        upperHintsScope.add(createFieldRowPanel("📝 Plain Library Name", plainLibNameField, "Specify to skip packaging into JAR"));
+        upperHintsScope.add(createFieldRowPanel("Plain library name", plainLibNameField, "Specify to skip packaging into JAR"));
         upperHintsScope.add(Box.createRigidArea(new Dimension(0, 8)));
 
         // Custom Library Dir
-        upperHintsScope.add(createFieldRowPanel("📁 Custom Library Dir (in jar)", customLibDirField, "e.g. native/win64 — inside output JAR"));
+        upperHintsScope.add(createFieldRowPanel("Custom library directory (in jar)", customLibDirField, "e.g. native/win64 — inside output JAR"));
         upperHintsScope.add(Box.createRigidArea(new Dimension(0, 8)));
 
         form.add(upperHintsScope);
@@ -278,7 +275,7 @@ public class ObfuscatorFrame extends JFrame {
         platformPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
         platformPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, ROW_H));
 
-        JLabel platformLabel = new JLabel("💻 Platform");
+        JLabel platformLabel = new JLabel("Platform");
         platformLabel.setPreferredSize(new Dimension(LABEL_W, FIELD_H));
         platformLabel.setAlignmentY(Component.CENTER_ALIGNMENT);
         platformLabel.setVerticalAlignment(SwingConstants.CENTER);
@@ -295,7 +292,7 @@ public class ObfuscatorFrame extends JFrame {
         // Build Options
         JPanel buildOpts = new JPanel();
         buildOpts.setLayout(new BoxLayout(buildOpts, BoxLayout.Y_AXIS));
-        buildOpts.setBorder(new TitledBorder("🔧 Build Options"));
+        buildOpts.setBorder(new TitledBorder("Build options"));
         buildOpts.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         JPanel line1 = new JPanel();
@@ -318,17 +315,17 @@ public class ObfuscatorFrame extends JFrame {
         // Protection Features：单独 scope，单独计算 hint 宽度
         JPanel protectionPanel = new JPanel();
         protectionPanel.setLayout(new BoxLayout(protectionPanel, BoxLayout.Y_AXIS));
-        protectionPanel.setBorder(new TitledBorder("🛡️ Protection Features"));
+        protectionPanel.setBorder(new TitledBorder("Protection features"));
         protectionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
         protectionPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 200));
 
         protectionPanel.add(checkWithHint(enableVirtualizationBox,
-                "🛡️ Translate selected methods to a custom VM; strongest protection"));
+                "Translate selected methods to a custom VM; strongest protection"));
         enableJitBox.setEnabled(false);
         protectionPanel.add(indent(checkWithHint(enableJitBox,
-                "⚡ JIT for virtualized methods; improves runtime performance"), 20));
+                "JIT for virtualized methods; improves runtime performance"), 20));
         protectionPanel.add(checkWithHint(flattenControlFlowBox,
-                "🌀 State-machine style CFG flattening for native methods"));
+                "State-machine style CFG flattening for native methods"));
 
         form.add(protectionPanel);
         form.add(Box.createVerticalGlue());
@@ -340,11 +337,11 @@ public class ObfuscatorFrame extends JFrame {
         card.add(sc, BorderLayout.CENTER);
 
         JPanel footer = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        JButton back = new JButton("← Back 📁");
+        JButton back = new JButton("← Back to import");
         back.addActionListener(e -> { leftNav.setSelectedIndex(0); showCard(CARD_IMPORT); });
-        JButton saveDefaults = new JButton("💾 Save as Defaults");
+        JButton saveDefaults = new JButton("Save as defaults");
         saveDefaults.addActionListener(e -> savePreferences());
-        JButton goRun = new JButton("Continue → Run 🚀");
+        JButton goRun = new JButton("Continue → Run");
         goRun.addActionListener(e -> { leftNav.setSelectedIndex(2); showCard(CARD_RUN); });
         footer.add(back);
         footer.add(saveDefaults);
@@ -364,7 +361,7 @@ public class ObfuscatorFrame extends JFrame {
         top.add(actions, BorderLayout.EAST);
 
         progressBar.setIndeterminate(true);
-        progressBar.setString("⏳ Processing obfuscation...");
+        progressBar.setString("Processing obfuscation...");
         progressBar.setStringPainted(true);
         progressBar.setVisible(false);
         top.add(progressBar, BorderLayout.SOUTH);
@@ -372,7 +369,7 @@ public class ObfuscatorFrame extends JFrame {
         logArea.setEditable(false);
         logArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
         JScrollPane logScroll = new JScrollPane(logArea);
-        logScroll.setBorder(new TitledBorder("📜 Output Log"));
+        logScroll.setBorder(new TitledBorder("Output log"));
 
         card.add(top, BorderLayout.NORTH);
         card.add(logScroll, BorderLayout.CENTER);
@@ -402,14 +399,14 @@ public class ObfuscatorFrame extends JFrame {
 
         // Gap + Browse column (fixed width)
         row.add(Box.createRigidArea(new Dimension(8, 0)));
-        JButton browseBtn = new JButton("📂 Browse");
+        JButton browseBtn = new JButton("Browse");
         browseBtn.setPreferredSize(new Dimension(BROWSE_W, FIELD_H));
         browseBtn.setMaximumSize(new Dimension(BROWSE_W, FIELD_H));
         browseBtn.setAlignmentY(Component.CENTER_ALIGNMENT);
         browseBtn.addActionListener(e -> browseAction.run());
         row.add(browseBtn);
 
-        // Hint column (fixed width so fields stay equal)
+        // Hint column (auto-sized per content)
         row.add(Box.createRigidArea(new Dimension(8, 0)));
         JLabel hint = makeHint(hintText == null ? "" : hintText);
         row.add(hint);
@@ -458,37 +455,25 @@ public class ObfuscatorFrame extends JFrame {
 
 
 
-    private int measureHintWidth(JLabel lbl) {
-        FontMetrics fm = lbl.getFontMetrics(lbl.getFont());
-        int w = fm.stringWidth(lbl.getText());
-        Insets in = lbl.getInsets();
-        if (in != null) w += in.left + in.right;
-        w += HINT_PADDING;
-        return Math.max(HINT_MIN_W, Math.min(HINT_MAX_W, w));
-    }
-
-    private void sizeAndLockHint(JLabel hint) {
-        int w = measureHintWidth(hint);
-        Dimension d = new Dimension(w, 18);
-        hint.setPreferredSize(d);
-        hint.setMaximumSize(d);
+    private void updateHintSize(JLabel hint) {
+        Dimension preferred = hint.getPreferredSize();
+        hint.setPreferredSize(preferred);
+        hint.setMaximumSize(new Dimension(preferred.width, preferred.height));
     }
 
     private void initPerHintAutoSize(final JLabel hint) {
-        sizeAndLockHint(hint);
+        updateHintSize(hint);
 
         hint.addHierarchyListener(e -> {
             if ((e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0 && hint.isShowing()) {
-                SwingUtilities.invokeLater(() -> sizeAndLockHint(hint));
+                SwingUtilities.invokeLater(() -> updateHintSize(hint));
             }
         });
 
-        hint.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
-            @Override public void propertyChange(java.beans.PropertyChangeEvent evt) {
-                String n = evt.getPropertyName();
-                if ("text".equals(n) || "font".equals(n)) {
-                    sizeAndLockHint(hint);
-                }
+        hint.addPropertyChangeListener(evt -> {
+            String name = evt.getPropertyName();
+            if ("text".equals(name) || "font".equals(name)) {
+                updateHintSize(hint);
             }
         });
     }
@@ -646,7 +631,7 @@ public class ObfuscatorFrame extends JFrame {
         showCard(CARD_RUN);
         setFormEnabled(false);
         progressBar.setVisible(true);
-        appendLog("🚀 Starting obfuscation...\n");
+        appendLog("Starting obfuscation...\n");
 
         SwingWorker<Integer, String> worker = new SwingWorker<Integer, String>() {
             @Override protected Integer doInBackground() throws Exception {
@@ -682,11 +667,11 @@ public class ObfuscatorFrame extends JFrame {
                 boolean enableJit = enableJitBox.isSelected();
                 boolean flattenControlFlow = flattenControlFlowBox.isSelected();
 
-                publish("🛡️ Protection settings:");
-                publish("  🖥️ VM Virtualization: " + (enableVirtualization ? "✅ Enabled" : "❌ Disabled"));
+                publish("Protection settings:");
+                publish("  VM virtualization: " + (enableVirtualization ? "enabled" : "disabled"));
                 if (enableVirtualization)
-                    publish("  ⚡ JIT Compilation: " + (enableJit ? "✅ Enabled" : "❌ Disabled"));
-                publish("  🌀 Control Flow Flattening: " + (flattenControlFlow ? "✅ Enabled" : "❌ Disabled"));
+                    publish("  JIT compilation: " + (enableJit ? "enabled" : "disabled"));
+                publish("  Control flow flattening: " + (flattenControlFlow ? "enabled" : "disabled"));
                 publish("");
 
                 NativeObfuscator obfuscator = new NativeObfuscator();
@@ -700,9 +685,9 @@ public class ObfuscatorFrame extends JFrame {
                     Path cppDir = Paths.get(outDir, "cpp");
                     runCmakeAndPackage(cppDir, new File(outDir, jarFile.getName()).toPath(), obfuscator.getNativeDir());
                 } else if (plainName != null) {
-                    appendLog("📝 Plain library mode selected; skipping jar packaging.\n");
+                    appendLog("Plain library mode selected; skipping jar packaging.\n");
                 } else {
-                    appendLog("❌ Packaging disabled by user.\n");
+                    appendLog("Packaging disabled by user.\n");
                 }
                 return 0;
             }
@@ -714,12 +699,12 @@ public class ObfuscatorFrame extends JFrame {
             @Override protected void done() {
                 try {
                     get();
-                    appendLog("✅ Done. Output at: " + outDir + "\n");
-                    JOptionPane.showMessageDialog(ObfuscatorFrame.this, "✅ Obfuscation completed successfully!", "✨ Success", JOptionPane.INFORMATION_MESSAGE);
+                    appendLog("Done. Output at: " + outDir + "\n");
+                    JOptionPane.showMessageDialog(ObfuscatorFrame.this, "Obfuscation completed successfully.", "Success", JOptionPane.INFORMATION_MESSAGE);
                 } catch (ExecutionException ex) {
                     Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
                     appendLogError(cause);
-                    JOptionPane.showMessageDialog(ObfuscatorFrame.this, "❌ " + (cause.getMessage() == null ? cause.toString() : cause.getMessage()), "⚠️ Error", JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(ObfuscatorFrame.this, (cause.getMessage() == null ? cause.toString() : cause.getMessage()), "Error", JOptionPane.ERROR_MESSAGE);
                 } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();
                 } finally {
@@ -768,7 +753,7 @@ public class ObfuscatorFrame extends JFrame {
     private void appendLogError(Throwable t) {
         String msg = (t.getMessage() == null) ? t.toString() : t.getMessage();
         StringBuilder sb = new StringBuilder();
-        sb.append("❌ ERROR: ").append(msg).append('\n');
+        sb.append("ERROR: ").append(msg).append('\n');
         for (StackTraceElement el : t.getStackTrace()) sb.append("    at ").append(el).append('\n');
         appendLog(sb.toString());
     }
@@ -776,14 +761,14 @@ public class ObfuscatorFrame extends JFrame {
     private void savePreferences() {
         prefs.put(PREF_LAST_JAR_DIR, new File(jarField.getText().trim()).getParent());
         prefs.put(PREF_LAST_ANY_DIR, new File(outDirField.getText().trim()).getParent());
-        JOptionPane.showMessageDialog(this, "💾 Defaults saved successfully!");
+        JOptionPane.showMessageDialog(this, "Defaults saved successfully.");
     }
 
     private void runCmakeAndPackage(Path cppDir, Path outJar, String nativeDir) throws IOException, InterruptedException {
         if (!Files.isDirectory(cppDir)) throw new IOException("C++ output directory not found: " + cppDir);
-        appendLog("\n🔧 Configuring CMake...\n");
+        appendLog("\nConfiguring CMake...\n");
         runProcess(new String[]{"cmake", "."}, cppDir.toFile());
-        appendLog("\n🔨 Building native library (Release)...\n");
+        appendLog("\nBuilding native library (Release)...\n");
         runProcess(new String[]{"cmake", "--build", ".", "--config", "Release"}, cppDir.toFile());
         Path libDir = cppDir.resolve("build").resolve("lib");
         if (!Files.isDirectory(libDir)) throw new IOException("Native lib dir not found: " + libDir);
@@ -796,9 +781,9 @@ public class ObfuscatorFrame extends JFrame {
         String arch = System.getProperty("os.arch").toLowerCase();
         String os = System.getProperty("os.name").toLowerCase();
         String entryPath = getEntryPath(nativeDir, arch, os);
-        appendLog("\n📦 Packaging native lib into jar at /" + entryPath + "...\n");
+        appendLog("\nPackaging native library into jar at /" + entryPath + "...\n");
         packageIntoJar(outJar, libFile.toPath(), entryPath);
-        appendLog("✅ Packaging completed.\n");
+        appendLog("Packaging completed.\n");
     }
 
     private static String getEntryPath(String nativeDir, String arch, String os) {


### PR DESCRIPTION
## Summary
- auto-size hint labels based on preferred width to avoid shared fixed columns
- replace emoji-laden copy with plain text across controls, placeholders and logs

## Testing
- ./gradlew --console=plain :obfuscator:check

------
https://chatgpt.com/codex/tasks/task_e_68cabb10dedc8332b687a4dde0cc88de