### PR TITLE
Fix class cache declaration ordering

### DIFF
--- a/analysis/performance_analysis.md
+++ b/analysis/performance_analysis.md
@@ -1,0 +1,31 @@
+# Native backend performance analysis (Calc benchmark)
+
+## Benchmark recap
+The provided `Calc` benchmark performs 10 000 iterations of three methods:
+1. `call(100)` – 100 levels of recursion incrementing the static `count` field at the base case.
+2. `runAdd()` – a tight floating-point loop up to 100.1 with increments of 0.99.
+3. `runStr()` – repeated string concatenation until the length exceeds 101 characters.
+
+Empirical timings with VM virtualization disabled show ~640 ms without control-flow flattening and ~762 ms with flattening enabled, so the native translation is still slower than desired.
+
+## Where the time is spent
+
+### 1. JNI round-trips for every field increment
+With virtualization disabled, `MethodProcessor` emits the state-machine based native method body. Every Java `getstatic`/`putstatic` becomes an explicit JNI call (`GetStatic*Field`, `SetStatic*Field`) in the generated snippets.【F:obfuscator/src/main/resources/sources/cppsnippets.properties†L254-L320】 The field handler wraps each access with cache checks that rely on `env->IsSameObject` and mutex locking even when the cached weak global reference is valid.【F:obfuscator/src/main/java/by/radioegor146/instructions/FieldHandler.java†L15-L56】 As a result, each `++count` in `call(int)` issues two JNI calls and multiple cache checks. Because the recursion depth is 100, a single invocation of `call(100)` performs roughly 200 JNI transitions; 10 000 loop iterations therefore execute on the order of two million JNI field operations, dominating total time.
+
+### 2. Per-invocation scaffolding overhead
+The fallback state-machine emitter always allocates `jvalue` arrays for operand stack/locals and instantiates a `std::unordered_set<jobject>` to track references, even if the method never touches objects.【F:obfuscator/src/main/java/by/radioegor146/MethodProcessor.java†L610-L707】 For `call(int)` and `runAdd()` this means every recursive frame pays for constructing and later destroying an empty hash set, causing substantial allocator churn. The dispatcher also records per-instruction comments and emits state labels, adding extra branches when control-flow flattening is enabled.【F:obfuscator/src/main/java/by/radioegor146/MethodProcessor.java†L647-L720】 This explains the ~120 ms slowdown observed when flattening is toggled on: more state transitions and branch mispredictions on top of the existing JNI work.
+
+### 3. High cost of translated object operations in `runStr()`
+`runStr()` triggers repeated string concatenations. Each `NEW`, `INVOKESPECIAL`, and `INVOKEVIRTUAL` is lowered to cache-checked JNI calls (`CallNonvirtualObjectMethod`, `CallObjectMethod`, etc.), guarded by the same `env->IsSameObject` mutex pattern as fields and followed by method-ID lookups and argument marshaling.【F:obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java†L151-L220】【F:obfuscator/src/main/resources/sources/cppsnippets.properties†L413-L449】 Although method/field IDs are cached after the first hit, the guard code and JNI transitions remain on the hot path for every concatenation. This keeps string-heavy workloads far from native performance even with string obfuscation disabled.
+
+### 4. Virtual machine pipeline is bypassed but its guards still run
+The compiler only emits micro-VM bytecode when virtualization is enabled; otherwise it falls back to the generic dispatcher described above.【F:obfuscator/src/main/java/by/radioegor146/MethodProcessor.java†L194-L224】 Because virtualization was disabled during the benchmark, the micro VM (`micro_vm.cpp`) did not execute, so the remaining overhead is entirely due to the JNI-heavy state machine and CFG flattening logic.
+
+## Key takeaways and mitigation ideas
+* **Reduce JNI crossings for simple fields.** For arithmetic counters such as `count`, consider emitting direct memory accesses when the field is in the same class module or caching the static value in a native shadow variable to batch updates before flushing through JNI.
+* **Avoid allocating reference-tracking sets when unnecessary.** A compile-time escape analysis flag (e.g., only create `refs` if the method actually touches reference types) would eliminate millions of redundant hash-set constructions on primitive-only paths.
+* **Let control-flow flattening be selective.** Restrict flattening to code that truly benefits from obfuscation. For tight arithmetic loops the additional dispatcher hops cost more than they obfuscate.
+* **Batch string operations or hand off to the JVM sooner.** Methods like `runStr()` are dominated by repeated JNI calls; detecting common StringBuilder patterns and delegating them back to Java would avoid expensive native ↔ JVM transitions.
+
+Addressing these areas should yield much larger gains than toggling individual obfuscation switches in isolation.

--- a/obfuscator/src/main/java/by/radioegor146/MethodContext.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodContext.java
@@ -62,6 +62,11 @@ public class MethodContext {
     public boolean enumSwitchMapOnStack;
     public boolean lastWasEnumOrdinal;
 
+    private final LinkedHashMap<Integer, Integer> classCacheIndices = new LinkedHashMap<>();
+    private final Set<Integer> emittedClassGuards = new HashSet<>();
+    private int nextClassCacheIndex = 0;
+    private int classDeclarationsInsertPos = -1;
+
     public MethodContext(NativeObfuscator obfuscator, MethodNode method, int methodIndex, ClassNode clazz,
                          int classIndex, ProtectionConfig protectionConfig) {
         this.obfuscator = obfuscator;
@@ -79,6 +84,36 @@ public class MethodContext {
         this.locals = new ArrayList<>();
         this.tryCatches = new HashSet<>();
         this.catches = new HashMap<>();
+    }
+
+    public int ensureClassCacheIndex(int classId) {
+        Integer existing = classCacheIndices.get(classId);
+        if (existing != null) {
+            return existing;
+        }
+        int index = nextClassCacheIndex++;
+        classCacheIndices.put(classId, index);
+        return index;
+    }
+
+    public boolean markClassGuardGenerated(int classId) {
+        return emittedClassGuards.add(classId);
+    }
+
+    public boolean isClassGuardGenerated(int classId) {
+        return emittedClassGuards.contains(classId);
+    }
+
+    public LinkedHashMap<Integer, Integer> getClassCacheIndices() {
+        return classCacheIndices;
+    }
+
+    public void setClassDeclarationsInsertPos(int pos) {
+        this.classDeclarationsInsertPos = pos;
+    }
+
+    public int getClassDeclarationsInsertPos() {
+        return classDeclarationsInsertPos;
     }
 
     public NodeCache<String> getCachedStrings() {

--- a/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
@@ -54,6 +54,14 @@ public class MethodProcessor {
             1, 1, 1, 2, 2, 0, 0, 0, 0
     };
 
+    private static String classLocalVarName(int index) {
+        return "__ngen_cached_class_" + index;
+    }
+
+    private static String classGuardVarName(int index) {
+        return "__ngen_class_guard_" + index;
+    }
+
     private final NativeObfuscator obfuscator;
     private final InstructionHandlerContainer<?>[] handlers;
 
@@ -110,6 +118,35 @@ public class MethodProcessor {
             desc = desc.substring(1, desc.length() - 1);
         }
         return "utils::find_class_wo_static(env, classloader, " + context.getCachedStrings().getPointer(desc.replace('/', '.')) + ")";
+    }
+
+    public static String ensureClassStrongRef(MethodContext context, String internalName, String trimmedTryCatchBlock) {
+        int classId = context.getCachedClasses().getId(internalName);
+        int cacheIndex = context.ensureClassCacheIndex(classId);
+        String localVar = classLocalVarName(cacheIndex);
+        String guardVar = classGuardVarName(cacheIndex);
+
+        if (context.markClassGuardGenerated(classId)) {
+            context.output.append(String.format(
+                    "if (%1$s == nullptr) { if (!%2$s) { %2$s = true; if (!cclasses[%3$d] || env->IsSameObject(cclasses[%3$d], NULL)) { cclasses_mtx[%3$d].lock(); if (!cclasses[%3$d] || env->IsSameObject(cclasses[%3$d], NULL)) { if (jclass clazz = %4$s) { cclasses[%3$d] = (jclass) env->NewWeakGlobalRef(clazz); env->DeleteLocalRef(clazz); } } cclasses_mtx[%3$d].unlock(); %5$s } } %1$s = (jclass) env->NewLocalRef(cclasses[%3$d]); %5$s }\n",
+                    localVar,
+                    guardVar,
+                    classId,
+                    getClassGetter(context, internalName),
+                    trimmedTryCatchBlock));
+        }
+
+        return localVar;
+    }
+
+    public static String getClassStrongRefName(MethodContext context, int classId) {
+        int cacheIndex = context.ensureClassCacheIndex(classId);
+        return classLocalVarName(cacheIndex);
+    }
+
+    public static String getClassStrongRefName(MethodContext context, String internalName) {
+        int classId = context.getCachedClasses().getId(internalName);
+        return getClassStrongRefName(context, classId);
     }
 
     public void processMethod(MethodContext context) {
@@ -579,6 +616,8 @@ public class MethodProcessor {
                     CPP_TYPES[context.ret.getSort()])).append(" }\n");
         }
         output.append("    jobject lookup = nullptr;\n");
+        output.append("\n");
+        context.setClassDeclarationsInsertPos(output.length());
 
         if (method.tryCatchBlocks != null) {
             for (TryCatchBlockNode tryCatch : method.tryCatchBlocks) {
@@ -588,22 +627,12 @@ public class MethodProcessor {
             }
             Set<String> classesForTryCatches = method.tryCatchBlocks.stream().filter((tryCatchBlock) -> (tryCatchBlock.type != null)).map(x -> x.type)
                     .collect(Collectors.toSet());
+            String tryCatchGuard = String.format("if (env->ExceptionCheck()) { return (%s) 0; }",
+                    CPP_TYPES[context.ret.getSort()]);
             classesForTryCatches.forEach((clazz) -> {
-                int classId = context.getCachedClasses().getId(clazz);
-
                 context.output.append(String.format("    // try-catch-class %s\n", Util.escapeCommentString(clazz)));
-                context.output.append(String.format("    if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { cclasses_mtx[%d].lock(); "
-                                + "if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { if (jclass clazz = %s) { cclasses[%d] = (jclass) env->NewWeakGlobalRef(clazz); env->DeleteLocalRef(clazz); } } "
-                                + "cclasses_mtx[%d].unlock(); if (env->ExceptionCheck()) { return (%s) 0; } }\n",
-                        classId,
-                        classId,
-                        classId,
-                        classId,
-                        classId,
-                        getClassGetter(context, clazz),
-                        classId,
-                        classId,
-                        CPP_TYPES[context.ret.getSort()]));
+                context.output.append("    ");
+                ensureClassStrongRef(context, clazz, tryCatchGuard);
             });
         }
 
@@ -764,7 +793,7 @@ public class MethodProcessor {
                 }
                 catchBody.append("            ")
                         .append(context.getSnippet("TRYCATCH_CHECK_STACK", Util.createMap(
-                                "exception_class_ptr", context.getCachedClasses().getPointer(currentCatchBlock.getClazz()),
+                                "exception_class_ptr", getClassStrongRefName(context, currentCatchBlock.getClazz()),
                                 "handler_block", context.getLabelPool().getName(currentCatchBlock.getHandler().getLabel())
                         )))
                         .append("\n");
@@ -805,6 +834,7 @@ public class MethodProcessor {
         } else {
             output.append(buildLinearControlFlow(stateBlocks, defaultBlock, referencedStates));
         }
+        insertClassCacheDeclarations(context);
         output.append("}\n");
 
         context.stateObfuscation = null;
@@ -863,6 +893,33 @@ public class MethodProcessor {
             }
         }
         return linear.toString();
+    }
+
+    private static void insertClassCacheDeclarations(MethodContext context) {
+        int insertPos = context.getClassDeclarationsInsertPos();
+        if (insertPos < 0) {
+            return;
+        }
+        String declarations = buildClassCacheDeclarations(context);
+        if (declarations.isEmpty()) {
+            return;
+        }
+        context.output.insert(insertPos, declarations);
+    }
+
+    private static String buildClassCacheDeclarations(MethodContext context) {
+        if (context.getClassCacheIndices().isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int index : context.getClassCacheIndices().values()) {
+            sb.append("    jclass ").append(classLocalVarName(index)).append(" = nullptr;\n");
+        }
+        for (int index : context.getClassCacheIndices().values()) {
+            sb.append("    bool ").append(classGuardVarName(index)).append(" = false;\n");
+        }
+        sb.append('\n');
+        return sb.toString();
     }
 
     private static String linearizeStateAssignments(String code) {

--- a/obfuscator/src/main/java/by/radioegor146/instructions/FieldHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/FieldHandler.java
@@ -16,22 +16,10 @@ public class FieldHandler extends GenericInstructionHandler<FieldInsnNode> {
         CachedFieldInfo info = new CachedFieldInfo(node.owner, node.name, node.desc, isStatic);
 
         instructionName += "_" + Type.getType(node.desc).getSort();
-        if (isStatic) {
-            props.put("class_ptr", context.getCachedClasses().getPointer(node.owner));
-        }
+        String classLocal = MethodProcessor.ensureClassStrongRef(context, node.owner, trimmedTryCatchBlock);
+        props.put("class_ptr", classLocal);
 
         int classId = context.getCachedClasses().getId(node.owner);
-
-        context.output.append(String.format("if (!cclasses[%d]  || env->IsSameObject(cclasses[%d], NULL)) { cclasses_mtx[%d].lock(); if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { if (jclass clazz = %s) { cclasses[%d] = (jclass) env->NewWeakGlobalRef(clazz); env->DeleteLocalRef(clazz); } } cclasses_mtx[%d].unlock(); %s } ",
-                classId,
-                classId,
-                classId,
-                classId,
-                classId,
-                MethodProcessor.getClassGetter(context, node.owner),
-                classId,
-                classId,
-                trimmedTryCatchBlock));
 
         // Mirror JVM semantics: static field access triggers class initialization.
         if (isStatic) {
@@ -50,7 +38,7 @@ public class FieldHandler extends GenericInstructionHandler<FieldInsnNode> {
                 fieldId,
                 fieldId,
                 isStatic ? "Static" : "",
-                context.getCachedClasses().getPointer(node.owner),
+                classLocal,
                 context.getStringPool().get(node.name),
                 context.getStringPool().get(node.desc),
                 trimmedTryCatchBlock));

--- a/obfuscator/src/main/java/by/radioegor146/instructions/LdcHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/LdcHandler.java
@@ -143,19 +143,9 @@ public class LdcHandler extends GenericInstructionHandler<LdcInsnNode> {
         } else if (cst instanceof Type) {
             instructionName += "_CLASS";
 
-            int classId = context.getCachedClasses().getId(node.cst.toString());
-            context.output.append(String.format("if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { cclasses_mtx[%d].lock(); if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { if (jclass clazz = %s) { cclasses[%d] = (jclass) env->NewWeakGlobalRef(clazz); env->DeleteLocalRef(clazz); } } cclasses_mtx[%d].unlock(); %s } ",
-                    classId,
-                    classId,
-                    classId,
-                    classId,
-                    classId,
-                    MethodProcessor.getClassGetter(context, node.cst.toString()),
-                    classId,
-                    classId,
-                    trimmedTryCatchBlock));
-            
-            props.put("cst_ptr", context.getCachedClasses().getPointer(node.cst.toString()));
+            String classLocal = MethodProcessor.ensureClassStrongRef(context, node.cst.toString(), trimmedTryCatchBlock);
+
+            props.put("cst_ptr", classLocal);
         } else {
             throw new UnsupportedOperationException();
         }

--- a/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
@@ -180,22 +180,12 @@ public class MethodHandler extends GenericInstructionHandler<MethodInsnNode> {
         props.put("objectstackprev", String.valueOf(objectStackPrev));
         props.put("returnstackindex", String.valueOf(objectStackIndex));
 
+        String classLocal = MethodProcessor.ensureClassStrongRef(context, node.owner, trimmedTryCatchBlock);
         if (isStatic || node.getOpcode() == Opcodes.INVOKESPECIAL) {
-            props.put("class_ptr", context.getCachedClasses().getPointer(node.owner));
+            props.put("class_ptr", classLocal);
         }
 
         int classId = context.getCachedClasses().getId(node.owner);
-
-        context.output.append(String.format("if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { cclasses_mtx[%d].lock(); if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { if (jclass clazz = %s) { cclasses[%d] = (jclass) env->NewWeakGlobalRef(clazz); env->DeleteLocalRef(clazz); } } cclasses_mtx[%d].unlock(); %s } ",
-                classId,
-                classId,
-                classId,
-                classId,
-                classId,
-                MethodProcessor.getClassGetter(context, node.owner),
-                classId,
-                classId,
-                trimmedTryCatchBlock));
 
         if (isStatic) {
             String dotted = node.owner.replace('/', '.');
@@ -215,7 +205,7 @@ public class MethodHandler extends GenericInstructionHandler<MethodInsnNode> {
                         methodId,
                         methodId,
                         isStatic ? "Static" : "",
-                        context.getCachedClasses().getPointer(node.owner),
+                        classLocal,
                         context.getStringPool().get(node.name),
                         context.getStringPool().get(node.desc),
                         trimmedTryCatchBlock));

--- a/obfuscator/src/main/java/by/radioegor146/instructions/TypeHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/TypeHandler.java
@@ -12,19 +12,9 @@ public class TypeHandler extends GenericInstructionHandler<TypeInsnNode> {
     protected void process(MethodContext context, TypeInsnNode node) {
         props.put("desc", node.desc);
 
-        int classId = context.getCachedClasses().getId(node.desc);
-        context.output.append(String.format("if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { cclasses_mtx[%d].lock(); if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { if (jclass clazz = %s) { cclasses[%d] = (jclass) env->NewWeakGlobalRef(clazz); env->DeleteLocalRef(clazz); } } cclasses_mtx[%d].unlock(); %s } ",
-                classId,
-                classId,
-                classId,
-                classId,
-                classId,
-                MethodProcessor.getClassGetter(context, node.desc),
-                classId,
-                classId,
-                trimmedTryCatchBlock));
+        String classLocal = MethodProcessor.ensureClassStrongRef(context, node.desc, trimmedTryCatchBlock);
 
-        props.put("desc_ptr", context.getCachedClasses().getPointer(node.desc));
+        props.put("desc_ptr", classLocal);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- track per-method class cache indices and guard emission so each method owns strong class references
- add MethodProcessor helpers that emit reusable local class references and inject the corresponding declarations once per method
- switch field/method/type/class instruction handlers to reuse the per-method locals instead of repeating JNI guard blocks
- ensure the generated class cache declarations are inserted before any emitted JNI guards so the native output compiles

## Testing
- ./gradlew :obfuscator:check *(fails: repository is missing the by.radioegor146.FastRandom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68da5308990c8332910542c9a0df3aa5