### PR TITLE
Hoist class cache guards into per-method fast path

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
@@ -180,22 +180,13 @@ public class MethodHandler extends GenericInstructionHandler<MethodInsnNode> {
         props.put("objectstackprev", String.valueOf(objectStackPrev));
         props.put("returnstackindex", String.valueOf(objectStackIndex));
 
+        MethodProcessor.ClassCacheAccess classAccess = MethodProcessor.ensureClassHandle(
+                context, node.owner, trimmedTryCatchBlock);
+        context.output.append(classAccess.guard());
+
         if (isStatic || node.getOpcode() == Opcodes.INVOKESPECIAL) {
-            props.put("class_ptr", context.getCachedClasses().getPointer(node.owner));
+            props.put("class_ptr", classAccess.local());
         }
-
-        int classId = context.getCachedClasses().getId(node.owner);
-
-        context.output.append(String.format("if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { cclasses_mtx[%d].lock(); if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { if (jclass clazz = %s) { cclasses[%d] = (jclass) env->NewWeakGlobalRef(clazz); env->DeleteLocalRef(clazz); } } cclasses_mtx[%d].unlock(); %s } ",
-                classId,
-                classId,
-                classId,
-                classId,
-                classId,
-                MethodProcessor.getClassGetter(context, node.owner),
-                classId,
-                classId,
-                trimmedTryCatchBlock));
 
         if (isStatic) {
             String dotted = node.owner.replace('/', '.');
@@ -212,7 +203,7 @@ public class MethodHandler extends GenericInstructionHandler<MethodInsnNode> {
                         methodId,
                         methodId,
                         isStatic ? "Static" : "",
-                        context.getCachedClasses().getPointer(node.owner),
+                        classAccess.local(),
                         context.getStringPool().get(node.name),
                         context.getStringPool().get(node.desc),
                         trimmedTryCatchBlock));


### PR DESCRIPTION
## Summary
- track per-method class cache locals and declarations in `MethodContext`
- add a reusable helper in `MethodProcessor` that materializes local class references behind a single guard
- use the new helper from the field and method handlers to avoid repeating JNI slow paths

## Testing
- `./gradlew --console plain :obfuscator:test -Pjavaobf=false`


------
https://chatgpt.com/codex/tasks/task_e_68da5bfc5bcc8332a9b0a0f94e89c20c