### PR TITLE
Hoist class cache guards into per-method fast path

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/MethodContext.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodContext.java
@@ -62,6 +62,12 @@ public class MethodContext {
     public boolean enumSwitchMapOnStack;
     public boolean lastWasEnumOrdinal;
 
+    public final Map<Integer, String> verifiedClassLocals;
+    public final Map<Integer, String> verifiedClassFlagNames;
+    public final BitSet verifiedClassFlags;
+    public final StringBuilder verifiedClassPreamble;
+    public int verifiedClassPreambleInsertionPoint;
+
     public MethodContext(NativeObfuscator obfuscator, MethodNode method, int methodIndex, ClassNode clazz,
                          int classIndex, ProtectionConfig protectionConfig) {
         this.obfuscator = obfuscator;
@@ -79,6 +85,12 @@ public class MethodContext {
         this.locals = new ArrayList<>();
         this.tryCatches = new HashSet<>();
         this.catches = new HashMap<>();
+
+        this.verifiedClassLocals = new HashMap<>();
+        this.verifiedClassFlagNames = new HashMap<>();
+        this.verifiedClassFlags = new BitSet();
+        this.verifiedClassPreamble = new StringBuilder();
+        this.verifiedClassPreambleInsertionPoint = -1;
     }
 
     public NodeCache<String> getCachedStrings() {

--- a/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/MethodHandler.java
@@ -180,22 +180,12 @@ public class MethodHandler extends GenericInstructionHandler<MethodInsnNode> {
         props.put("objectstackprev", String.valueOf(objectStackPrev));
         props.put("returnstackindex", String.valueOf(objectStackIndex));
 
-        if (isStatic || node.getOpcode() == Opcodes.INVOKESPECIAL) {
-            props.put("class_ptr", context.getCachedClasses().getPointer(node.owner));
-        }
-
         int classId = context.getCachedClasses().getId(node.owner);
+        String classPtr = MethodProcessor.ensureVerifiedClass(context, classId, node.owner, trimmedTryCatchBlock);
 
-        context.output.append(String.format("if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { cclasses_mtx[%d].lock(); if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { if (jclass clazz = %s) { cclasses[%d] = (jclass) env->NewWeakGlobalRef(clazz); env->DeleteLocalRef(clazz); } } cclasses_mtx[%d].unlock(); %s } ",
-                classId,
-                classId,
-                classId,
-                classId,
-                classId,
-                MethodProcessor.getClassGetter(context, node.owner),
-                classId,
-                classId,
-                trimmedTryCatchBlock));
+        if (isStatic || node.getOpcode() == Opcodes.INVOKESPECIAL) {
+            props.put("class_ptr", classPtr);
+        }
 
         if (isStatic) {
             String dotted = node.owner.replace('/', '.');
@@ -215,7 +205,7 @@ public class MethodHandler extends GenericInstructionHandler<MethodInsnNode> {
                         methodId,
                         methodId,
                         isStatic ? "Static" : "",
-                        context.getCachedClasses().getPointer(node.owner),
+                        classPtr,
                         context.getStringPool().get(node.name),
                         context.getStringPool().get(node.desc),
                         trimmedTryCatchBlock));


### PR DESCRIPTION
## Summary
- add per-method tracking of verified class handles so JNI lookups only refresh weak globals once per method
- update field and method instruction handlers to reuse the cached local jclass references for ID resolution and call sites

## Testing
- ./gradlew :obfuscator:test --tests by.radioegor146.VmGetPutFieldPipelineTest

------
https://chatgpt.com/codex/tasks/task_e_68da67c94acc83329c0bd40948f29e64