### PR TITLE
Cache type instruction class handles per method

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/instructions/LdcHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/LdcHandler.java
@@ -144,18 +144,9 @@ public class LdcHandler extends GenericInstructionHandler<LdcInsnNode> {
             instructionName += "_CLASS";
 
             int classId = context.getCachedClasses().getId(node.cst.toString());
-            context.output.append(String.format("if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { cclasses_mtx[%d].lock(); if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { if (jclass clazz = %s) { cclasses[%d] = (jclass) env->NewWeakGlobalRef(clazz); env->DeleteLocalRef(clazz); } } cclasses_mtx[%d].unlock(); %s } ",
-                    classId,
-                    classId,
-                    classId,
-                    classId,
-                    classId,
-                    MethodProcessor.getClassGetter(context, node.cst.toString()),
-                    classId,
-                    classId,
-                    trimmedTryCatchBlock));
-            
-            props.put("cst_ptr", context.getCachedClasses().getPointer(node.cst.toString()));
+            String classPtr = MethodProcessor.ensureVerifiedClass(context, classId, node.cst.toString(), trimmedTryCatchBlock);
+
+            props.put("class_ptr", classPtr);
         } else {
             throw new UnsupportedOperationException();
         }

--- a/obfuscator/src/main/java/by/radioegor146/instructions/TypeHandler.java
+++ b/obfuscator/src/main/java/by/radioegor146/instructions/TypeHandler.java
@@ -13,18 +13,9 @@ public class TypeHandler extends GenericInstructionHandler<TypeInsnNode> {
         props.put("desc", node.desc);
 
         int classId = context.getCachedClasses().getId(node.desc);
-        context.output.append(String.format("if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { cclasses_mtx[%d].lock(); if (!cclasses[%d] || env->IsSameObject(cclasses[%d], NULL)) { if (jclass clazz = %s) { cclasses[%d] = (jclass) env->NewWeakGlobalRef(clazz); env->DeleteLocalRef(clazz); } } cclasses_mtx[%d].unlock(); %s } ",
-                classId,
-                classId,
-                classId,
-                classId,
-                classId,
-                MethodProcessor.getClassGetter(context, node.desc),
-                classId,
-                classId,
-                trimmedTryCatchBlock));
+        String classPtr = MethodProcessor.ensureVerifiedClass(context, classId, node.desc, trimmedTryCatchBlock);
 
-        props.put("desc_ptr", context.getCachedClasses().getPointer(node.desc));
+        props.put("class_ptr", classPtr);
     }
 
     @Override

--- a/obfuscator/src/main/resources/sources/cppsnippets.properties
+++ b/obfuscator/src/main/resources/sources/cppsnippets.properties
@@ -37,7 +37,7 @@ LDC_LONG=cstack$stackindex0.j = native_jvm::utils::decode_long($enc, $key, $mid,
 LDC_LONG_RAW=cstack$stackindex0.j = $value;
 LDC_DOUBLE=cstack$stackindex0.d = native_jvm::utils::decode_double($enc, $key, $mid, $cid, $seed);
 LDC_DOUBLE_RAW=cstack$stackindex0.d = $value;
-LDC_CLASS=cstack$stackindex0.l = $cst_ptr;
+LDC_CLASS=cstack$stackindex0.l = $class_ptr; refs.insert(cstack$stackindex0.l);
 ILOAD=cstack$stackindex0.i = clocal$var.i;
 LLOAD=cstack$stackindex0.j = clocal$var.j;
 FLOAD=cstack$stackindex0.f = clocal$var.f;
@@ -211,8 +211,8 @@ FRETURN=return ($rettype) cstack$stackindexm1.f;
 DRETURN=return ($rettype) cstack$stackindexm2.d;
 ARETURN=return ($rettype) cstack$stackindexm1.l;
 RETURN=return;
-NEW=if (jobject obj = env->AllocObject($desc_ptr)) { cstack$stackindex0.l = obj; refs.insert(obj); } $trycatchhandler
-ANEWARRAY=if (cstack$stackindexm1.i < 0) utils::throw_re(env, #NASE, #ERROR_DESC, $line); else { cstack$stackindexm1.l = env->NewObjectArray(cstack$stackindexm1.i, $desc_ptr, nullptr); refs.insert(cstack$stackindexm1.l); } $trycatchhandler
+NEW=if (jobject obj = env->AllocObject($class_ptr)) { cstack$stackindex0.l = obj; refs.insert(obj); } $trycatchhandler
+ANEWARRAY=if (cstack$stackindexm1.i < 0) utils::throw_re(env, #NASE, #ERROR_DESC, $line); else { cstack$stackindexm1.l = env->NewObjectArray(cstack$stackindexm1.i, $class_ptr, nullptr); refs.insert(cstack$stackindexm1.l); } $trycatchhandler
 ANEWARRAY_S_VARS=#NASE,#ERROR_DESC
 ANEWARRAY_S_CONST_NASE=java/lang/NegativeArraySizeException
 ANEWARRAY_S_CONST_ERROR_DESC=ANEWARRAY array size < 0
@@ -224,7 +224,7 @@ ATHROW=if (cstack$stackindexm1.l == nullptr) utils::throw_re(env, #NPE, #ERROR_D
 ATHROW_S_VARS=#NPE,#ERROR_DESC
 ATHROW_S_CONST_NPE=java/lang/NullPointerException
 ATHROW_S_CONST_ERROR_DESC=ATHROW npe
-INSTANCEOF=cstack$stackindexm1.i = cstack$stackindexm1.l == nullptr ? false : env->IsInstanceOf(cstack$stackindexm1.l, $desc_ptr);
+INSTANCEOF=cstack$stackindexm1.i = cstack$stackindexm1.l == nullptr ? false : env->IsInstanceOf(cstack$stackindexm1.l, $class_ptr);
 MONITORENTER=if (cstack$stackindexm1.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else env->MonitorEnter(cstack$stackindexm1.l); $trycatchhandler
 MONITORENTER_S_VARS=#NPE,#ERROR_DESC
 MONITORENTER_S_CONST_NPE=java/lang/NullPointerException
@@ -624,7 +624,7 @@ MULTIANEWARRAY=cstack$returnstackindex.l = utils::create_multidim_array(env, cla
 MULTIANEWARRAY_S_VARS=$desc
 MULTIANEWARRAY_VALUE=cstack$returnstackindex.l = utils::create_multidim_array_value<$sort>(env, $count, $required_count, $desc, $line, $dims); refs.insert(cstack$returnstackindex.l); $trycatchhandler
 MULTIANEWARRAY_VALUE_S_VARS=$desc
-CHECKCAST=if (cstack$stackindexm1.l != nullptr && !env->IsInstanceOf(cstack$stackindexm1.l, $desc_ptr)) { utils::throw_re(env, #CCE, (std::string(#ERROR_DESC) + std::string($desc)).c_str(), $line); $trycatchhandler } 
+CHECKCAST=if (cstack$stackindexm1.l != nullptr && !env->IsInstanceOf(cstack$stackindexm1.l, $class_ptr)) { utils::throw_re(env, #CCE, (std::string(#ERROR_DESC) + std::string($desc)).c_str(), $line); $trycatchhandler }
 CHECKCAST_S_VARS=#CCE,#ERROR_DESC,$desc
 CHECKCAST_S_CONST_CCE=java/lang/ClassCastException
 CHECKCAST_S_CONST_ERROR_DESC=cannot cast to 

--- a/obfuscator/src/test/java/by/radioegor146/MethodProcessorClassCachingTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/MethodProcessorClassCachingTest.java
@@ -1,0 +1,92 @@
+package by.radioegor146;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MethodProcessorClassCachingTest {
+
+    static class TypeLoopSample {
+        static Object loop(Object value, int iterations) {
+            Object result = null;
+            for (int i = 0; i < iterations; i++) {
+                if (value instanceof String) {
+                    result = (String) value;
+                }
+            }
+            return result;
+        }
+
+        static Class<?> classLiteralLoop(int iterations) {
+            Class<?> clazz = Object.class;
+            for (int i = 0; i < iterations; i++) {
+                clazz = String.class;
+            }
+            return clazz;
+        }
+    }
+
+    private NativeObfuscator obfuscator;
+    private MethodProcessor processor;
+    private ClassNode classNode;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        obfuscator = new NativeObfuscator();
+        processor = new MethodProcessor(obfuscator);
+
+        ClassReader cr = new ClassReader(TypeLoopSample.class.getName());
+        classNode = new ClassNode();
+        cr.accept(classNode, ClassReader.EXPAND_FRAMES);
+    }
+
+    private MethodContext createContext(String name, String desc) {
+        MethodNode target = null;
+        int index = -1;
+        for (int i = 0; i < classNode.methods.size(); i++) {
+            MethodNode candidate = classNode.methods.get(i);
+            if (Objects.equals(candidate.name, name) && Objects.equals(candidate.desc, desc)) {
+                target = candidate;
+                index = i;
+                break;
+            }
+        }
+        assertNotNull(target, "Expected method not found: " + name + desc);
+
+        return new MethodContext(obfuscator, target, index, classNode, 0, ProtectionConfig.createDefault());
+    }
+
+    @Test
+    void typeInstructionsReuseVerifiedClassLocals() {
+        MethodContext context = createContext("loop", "(Ljava/lang/Object;I)Ljava/lang/Object;");
+        processor.processMethod(context);
+
+        String output = context.output.toString();
+
+        assertTrue(output.contains("jclass cclass_local0 = nullptr;"), output);
+        assertTrue(output.contains("bool cclass_local0_cached = false;"), output);
+        assertTrue(output.contains("if (!cclass_local0_cached)"), output);
+        assertTrue(Pattern.compile("IsInstanceOf\\(cstack\\d+\\.l, cclass_local0\\)").matcher(output).find(), output);
+        assertFalse(Pattern.compile("IsInstanceOf\\(cstack\\d+\\.l, \\(?cclasses").matcher(output).find(), output);
+    }
+
+    @Test
+    void ldcClassUsesVerifiedClassLocal() {
+        MethodContext context = createContext("classLiteralLoop", "(I)Ljava/lang/Class;");
+        processor.processMethod(context);
+
+        String output = context.output.toString();
+
+        assertTrue(output.contains("bool cclass_local0_cached = false;"), output);
+        assertTrue(Pattern.compile("cstack\\d+\\.l = cclass_local0").matcher(output).find(), output);
+        assertTrue(Pattern.compile("refs.insert\\(cstack\\d+\\.l\\);").matcher(output).find(), output);
+        assertFalse(Pattern.compile("cstack\\d+\\.l = \\(?cclasses").matcher(output).find(), output);
+    }
+}


### PR DESCRIPTION
## Summary
- reuse the per-method verified class cache for TypeHandler and LdcHandler
- update JNI snippets to operate on cached local class handles instead of weak globals
- add regression coverage exercising instanceof/checkcast and class literal caching

## Testing
- ./gradlew :obfuscator:test --tests "by.radioegor146.MethodProcessorClassCachingTest"


------
https://chatgpt.com/codex/tasks/task_e_68da75535a50833288ce37c225584d03