### PR TITLE
Disable unstable Java control-flow flattening and fix plain string pool

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/source/StringPool.java
+++ b/obfuscator/src/main/java/by/radioegor146/source/StringPool.java
@@ -160,7 +160,9 @@ public class StringPool {
                 .mapToObj(String::valueOf)
                 .collect(Collectors.joining(", ")));
 
-        String template = Util.readResource("sources/string_pool.cpp");
+        String template = Util.readResource(obfuscateStrings
+                ? "sources/string_pool.cpp"
+                : "sources/string_pool_plain.cpp");
         return Util.dynamicFormat(template, Util.createMap(
                 "size", Math.max(1, encrypted.length) + "LL",
                 "value", poolArray

--- a/obfuscator/src/main/resources/sources/string_pool_plain.cpp
+++ b/obfuscator/src/main/resources/sources/string_pool_plain.cpp
@@ -1,0 +1,13 @@
+#include <cstddef>
+
+namespace native_jvm::string_pool {
+    static unsigned char pool[$size] = $value;
+
+    char *get_pool() {
+        return reinterpret_cast<char *>(pool);
+    }
+
+    std::size_t get_pool_size() {
+        return sizeof(pool);
+    }
+}

--- a/obfuscator/src/test/java/by/radioegor146/JavaObfuscatorFlattenTest.java
+++ b/obfuscator/src/test/java/by/radioegor146/JavaObfuscatorFlattenTest.java
@@ -41,7 +41,7 @@ public class JavaObfuscatorFlattenTest {
 
     @Test
     public void testJavaFlattenComplexCatchStack() throws Exception {
-        Path sampleRoot = Paths.get("obfuscator", "test_data", "tests", "java-obfuscator-test", "JavaObfuscatorTest");
+        Path sampleRoot = resolveTestDataPath("test_data", "tests", "java-obfuscator-test", "JavaObfuscatorTest");
         Path temp = Files.createTempDirectory("java-obf-pack-");
         try {
             Path srcDir = temp.resolve("src");
@@ -142,6 +142,18 @@ public class JavaObfuscatorFlattenTest {
             // best-effort cleanup
             try { Files.walk(temp).sorted(java.util.Comparator.reverseOrder()).forEach(p -> { try { Files.deleteIfExists(p); } catch (IOException ignored) {} }); } catch (IOException ignored) {}
         }
+    }
+
+    private static Path resolveTestDataPath(String first, String... more) throws IOException {
+        Path relative = Paths.get(first, more);
+        if (Files.exists(relative)) {
+            return relative;
+        }
+        Path moduleRelative = Paths.get("obfuscator").resolve(relative);
+        if (Files.exists(moduleRelative)) {
+            return moduleRelative;
+        }
+        throw new IOException("Unable to locate test data directory: " + relative);
     }
 
     private static void copyTree(Path source, Path target) throws IOException {


### PR DESCRIPTION
## Summary
- guard the Java switch-based flattening pass behind a feature flag, add extra safety checks, and fall back to only opaque predicates/dead code for medium/high strengths to avoid invalid stack frames
- add a plain string pool template and switch the builder to it when string obfuscation is disabled so generated code no longer references decode helpers
- make the complex Java flattening test resolve its input sources regardless of the current working directory

## Testing
- ./gradlew :obfuscator:test

------
https://chatgpt.com/codex/tasks/task_e_68dcb90951088332b3483581a541b65a