### PR TITLE
Optimize direct native calls for static methods

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/MethodContext.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodContext.java
@@ -1,6 +1,7 @@
 package by.radioegor146;
 
 import by.radioegor146.source.StringPool;
+import by.radioegor146.special.SpecialMethodProcessor;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -46,6 +47,21 @@ public class MethodContext {
     public MethodNode nativeMethod;
 
     public int stackPointer;
+
+    /**
+     * Indicates that {@link MethodProcessor#prepareForProcessing(MethodContext)} has
+     * already been invoked for this context. This prevents multiple
+     * invocations from re-running the pre-processing pipeline, which could
+     * otherwise duplicate side effects (e.g., toggling the native flag).
+     */
+    public boolean prepared;
+
+    /**
+     * The {@link SpecialMethodProcessor} instance used for this method. It is
+     * captured during the preparation phase so that the main processing logic
+     * and the post-processing step operate on the same handler instance.
+     */
+    public SpecialMethodProcessor specialProcessor;
 
     private final LabelPool labelPool = new LabelPool();
 


### PR DESCRIPTION
## Summary
- precompute native method metadata during the preparation phase so instruction handlers can reference native bindings without repeated JNI lookups
- cache native binding information per class and reuse it to skip JNI dispatch for same-class static invocations
- update the static invoke handler to call native implementations directly when available, reducing JNI overhead for recursive and intra-class calls

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68de3f1d458c8332b863327200e573da