### PR TITLE
Fix stack frame handling for native stubs

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/special/DefaultSpecialMethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/special/DefaultSpecialMethodProcessor.java
@@ -37,8 +37,8 @@ public class DefaultSpecialMethodProcessor implements SpecialMethodProcessor {
 
     @Override
     public void postProcess(MethodContext context) {
-        context.method.instructions.clear();
         if (Util.getFlag(context.clazz.access, Opcodes.ACC_INTERFACE)) {
+            context.method.instructions.clear();
             InsnList list = new InsnList();
 
             if (Util.getFlag(context.method.access, Opcodes.ACC_STATIC)) {
@@ -60,6 +60,13 @@ public class DefaultSpecialMethodProcessor implements SpecialMethodProcessor {
                     context.proxyMethod.getMethodNode().desc, false));
             list.add(new InsnNode(Type.getReturnType(context.method.desc).getOpcode(Opcodes.IRETURN)));
             context.method.instructions = list;
+        } else {
+            // For concrete classes the Java method is converted to a true native declaration.
+            // Ensure there is no residual bytecode, otherwise ASM will attempt to compute
+            // stack frames for a method flagged as native, leading to verification errors.
+            context.method.instructions.clear();
+            context.method.maxStack = 0;
+            context.method.maxLocals = 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure DefaultSpecialMethodProcessor removes bytecode for concrete methods when marking them native
- reset max stack/locals on native stubs to prevent ASM frame computation failures

## Testing
- `./gradlew test --no-daemon --console=plain`
- built and ran the provided sample jar before and after obfuscation to confirm matching output

------
https://chatgpt.com/codex/tasks/task_e_68de6bc091fc833283c04e1ba9c03c67