### PR TITLE
Improve transpiled array access performance

### DIFF
--- a/obfuscator/src/main/java/by/radioegor146/Main.java
+++ b/obfuscator/src/main/java/by/radioegor146/Main.java
@@ -61,11 +61,11 @@ public class Main {
         @CommandLine.Option(names = {"--flatten-control-flow"}, description = "Enable control flow flattening in native methods")
         private boolean flattenControlFlow;
 
-        @CommandLine.Option(names = {"--obfuscate-strings"}, defaultValue = "true",
+        @CommandLine.Option(names = {"--obfuscate-strings"}, negatable = true, defaultValue = "true",
                 description = "Encrypt string literals stored in the native string pool")
         private boolean obfuscateStrings = true;
 
-        @CommandLine.Option(names = {"--obfuscate-constants"}, defaultValue = "true",
+        @CommandLine.Option(names = {"--obfuscate-constants"}, negatable = true, defaultValue = "true",
                 description = "Encode primitive LDC constants and decode them at runtime")
         private boolean obfuscateConstants = true;
 

--- a/obfuscator/src/main/java/by/radioegor146/MethodContext.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodContext.java
@@ -71,6 +71,16 @@ public class MethodContext {
     // Used for direct C++ call optimization within the same class
     public Map<String, String> transpiledMethodNames;
 
+    // Pre-pass computed names for the currently processed method. The base name matches the
+    // value returned by {@link by.radioegor146.special.SpecialMethodProcessor#previewName}, while
+    // the C++ name already includes the generated prefix and escaping applied during codegen.
+    public String previewedBaseName;
+    public String previewedCppMethodName;
+
+    // Sequential index assigned to each INVOKEDYNAMIC site encountered while translating the
+    // current method. Used to build stable cache keys for MethodHandle call sites at runtime.
+    public int nextInvokeDynamicIndex;
+
     public MethodContext(NativeObfuscator obfuscator, MethodNode method, int methodIndex, ClassNode clazz,
                          int classIndex, ProtectionConfig protectionConfig) {
         this.obfuscator = obfuscator;

--- a/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/MethodProcessor.java
@@ -667,6 +667,8 @@ public class MethodProcessor {
         }
 
         output.append("    native_jvm::LocalRefSet refs;\n");
+        output.append("    native_jvm::utils::PrimitiveArrayCache primitive_arrays(env);\n");
+        output.append("    native_jvm::utils::ObjectArrayCache object_arrays(env);\n");
         output.append("\n");
         context.verifiedClassPreambleInsertionPoint = output.length();
 

--- a/obfuscator/src/main/java/by/radioegor146/special/ClInitSpecialMethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/special/ClInitSpecialMethodProcessor.java
@@ -10,6 +10,14 @@ import java.util.ArrayList;
 public class ClInitSpecialMethodProcessor implements SpecialMethodProcessor {
 
     @Override
+    public String previewName(MethodContext context) {
+        if (shouldKeepOriginalClinit(context)) {
+            return null;
+        }
+        return String.format("special_clinit_%d_%d", context.classIndex, context.methodIndex);
+    }
+
+    @Override
     public String preProcess(MethodContext context) {
         // Avoid transforming <clinit> for classes that are known to be fragile under
         // redirection on newer JVMs (e.g., enum classes and synthetic switch-map holders).

--- a/obfuscator/src/main/java/by/radioegor146/special/DefaultSpecialMethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/special/DefaultSpecialMethodProcessor.java
@@ -13,6 +13,18 @@ import java.util.stream.Collectors;
 
 public class DefaultSpecialMethodProcessor implements SpecialMethodProcessor {
 
+    private static String computeBaseName(MethodContext context) {
+        if (Util.getFlag(context.clazz.access, Opcodes.ACC_INTERFACE)) {
+            return String.format("interfacestatic_%d_%d", context.classIndex, context.methodIndex);
+        }
+        return "native_" + context.method.name + context.methodIndex;
+    }
+
+    @Override
+    public String previewName(MethodContext context) {
+        return computeBaseName(context);
+    }
+
     @Override
     public String preProcess(MethodContext context) {
         if (Util.getFlag(context.clazz.access, Opcodes.ACC_INTERFACE)) {
@@ -20,7 +32,7 @@ public class DefaultSpecialMethodProcessor implements SpecialMethodProcessor {
             arguments.add(0, Type.getType(Object.class));
             String resultDesc = Type.getMethodDescriptor(Type.getReturnType(context.method.desc), arguments.toArray(new Type[0]));
 
-            String methodName = String.format("interfacestatic_%d_%d", context.classIndex, context.methodIndex);
+            String methodName = computeBaseName(context);
             context.proxyMethod = context.obfuscator.getHiddenMethodsPool()
                     .getMethod(methodName, resultDesc, methodNode -> {
                         methodNode.signature = context.method.signature;
@@ -32,7 +44,7 @@ public class DefaultSpecialMethodProcessor implements SpecialMethodProcessor {
             return methodName;
         }
         context.method.access |= Opcodes.ACC_NATIVE;
-        return "native_" + context.method.name + context.methodIndex;
+        return computeBaseName(context);
     }
 
     @Override

--- a/obfuscator/src/main/java/by/radioegor146/special/SpecialMethodProcessor.java
+++ b/obfuscator/src/main/java/by/radioegor146/special/SpecialMethodProcessor.java
@@ -3,6 +3,18 @@ package by.radioegor146.special;
 import by.radioegor146.MethodContext;
 
 public interface SpecialMethodProcessor {
+    /**
+     * Compute the native stub name that will be emitted for the supplied method without
+     * mutating the {@link MethodContext}. Implementations should avoid performing any
+     * structural rewrites or marking the method as native here so the preview step can run
+     * safely before the full transpilation pass.
+     *
+     * @return the base native name (without the {@code __ngen_} prefix) or {@code null} when the
+     * method should be kept in Java bytecode form.
+     */
+    String previewName(MethodContext context);
+
     String preProcess(MethodContext context);
+
     void postProcess(MethodContext context);
 }

--- a/obfuscator/src/main/resources/sources/cppsnippets.properties
+++ b/obfuscator/src/main/resources/sources/cppsnippets.properties
@@ -43,75 +43,43 @@ LLOAD=cstack$stackindex0.j = clocal$var.j;
 FLOAD=cstack$stackindex0.f = clocal$var.f;
 DLOAD=cstack$stackindex0.d = clocal$var.d;
 ALOAD=cstack$stackindex0.l = clocal$var.l; refs.insert(cstack$stackindex0.l);
-IALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { env->GetIntArrayRegion((jintArray) cstack$stackindexm2.l, cstack$stackindexm1.i, 1, &cstack$stackindexm2.i); } $trycatchhandler
-IALOAD_S_VARS=#NPE,#ERROR_DESC
-IALOAD_S_CONST_NPE=java/lang/NullPointerException
-IALOAD_S_CONST_ERROR_DESC=IALOAD npe
-LALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { env->GetLongArrayRegion((jlongArray) cstack$stackindexm2.l, cstack$stackindexm1.i, 1, &cstack$stackindexm2.j); } $trycatchhandler
-LALOAD_S_VARS=#NPE,#ERROR_DESC
-LALOAD_S_CONST_NPE=java/lang/NullPointerException
-LALOAD_S_CONST_ERROR_DESC=LALOAD npe
-FALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { env->GetFloatArrayRegion((jfloatArray) cstack$stackindexm2.l, cstack$stackindexm1.i, 1, &cstack$stackindexm2.f); } $trycatchhandler
-FALOAD_S_VARS=#NPE,#ERROR_DESC
-FALOAD_S_CONST_NPE=java/lang/NullPointerException
-FALOAD_S_CONST_ERROR_DESC=FALOAD npe
-DALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { env->GetDoubleArrayRegion((jdoubleArray) cstack$stackindexm2.l, cstack$stackindexm1.i, 1, &cstack$stackindexm2.d); } $trycatchhandler
-DALOAD_S_VARS=#NPE,#ERROR_DESC
-DALOAD_S_CONST_NPE=java/lang/NullPointerException
-DALOAD_S_CONST_ERROR_DESC=DALOAD npe
-AALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { cstack$stackindexm2.l = env->GetObjectArrayElement((jobjectArray) cstack$stackindexm2.l, cstack$stackindexm1.i); refs.insert(cstack$stackindexm2.l); } $trycatchhandler
-AALOAD_S_VARS=#NPE,#ERROR_DESC
-AALOAD_S_CONST_NPE=java/lang/NullPointerException
-AALOAD_S_CONST_ERROR_DESC=AALOAD npe
-BALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { cstack$stackindexm2.i = (jint) utils::baload(env, (jarray) cstack$stackindexm2.l, cstack$stackindexm1.i); } $trycatchhandler
-BALOAD_S_VARS=#NPE,#ERROR_DESC
-BALOAD_S_CONST_NPE=java/lang/NullPointerException
-BALOAD_S_CONST_ERROR_DESC=BALOAD npe
-CALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { jchar temp = 0; env->GetCharArrayRegion((jcharArray) cstack$stackindexm2.l, cstack$stackindexm1.i, 1, &temp); cstack$stackindexm2.i = (jint) temp; } $trycatchhandler
-CALOAD_S_VARS=#NPE,#ERROR_DESC
-CALOAD_S_CONST_NPE=java/lang/NullPointerException
-CALOAD_S_CONST_ERROR_DESC=CALOAD npe
-SALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { jshort temp = 0; env->GetShortArrayRegion((jshortArray) cstack$stackindexm2.l, cstack$stackindexm1.i, 1, &temp); cstack$stackindexm2.i = (jint) temp; } $trycatchhandler
-SALOAD_S_VARS=#NPE,#ERROR_DESC
-SALOAD_S_CONST_NPE=java/lang/NullPointerException
-SALOAD_S_CONST_ERROR_DESC=SALOAD npe
 ISTORE=clocal$var.i = cstack$stackindexm1.i;
 LSTORE=clocal$var.j = cstack$stackindexm2.j;
 FSTORE=clocal$var.f = cstack$stackindexm1.f;
 DSTORE=clocal$var.d = cstack$stackindexm2.d;
 ASTORE=clocal$var.l = cstack$stackindexm1.l; refs.insert(cstack$stackindexm1.l);
-IASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { env->SetIntArrayRegion((jintArray) cstack$stackindexm3.l, cstack$stackindexm2.i, 1, &cstack$stackindexm1.i); } $trycatchhandler
-IASTORE_S_VARS=#NPE,#ERROR_DESC
-IASTORE_S_CONST_NPE=java/lang/NullPointerException
-IASTORE_S_CONST_ERROR_DESC=IASTORE npe
-LASTORE=if (cstack$stackindexm4.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { env->SetLongArrayRegion((jlongArray) cstack$stackindexm4.l, cstack$stackindexm3.i, 1, &cstack$stackindexm2.j); } $trycatchhandler
-LASTORE_S_VARS=#NPE,#ERROR_DESC
-LASTORE_S_CONST_NPE=java/lang/NullPointerException
-LASTORE_S_CONST_ERROR_DESC=LASTORE npe
-FASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { env->SetFloatArrayRegion((jfloatArray) cstack$stackindexm3.l, cstack$stackindexm2.i, 1, &cstack$stackindexm1.f); } $trycatchhandler
-FASTORE_S_VARS=#NPE,#ERROR_DESC
-FASTORE_S_CONST_NPE=java/lang/NullPointerException
-FASTORE_S_CONST_ERROR_DESC=FASTORE npe
-DASTORE=if (cstack$stackindexm4.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { env->SetDoubleArrayRegion((jdoubleArray) cstack$stackindexm4.l, cstack$stackindexm3.i, 1, &cstack$stackindexm2.d); } $trycatchhandler
-DASTORE_S_VARS=#NPE,#ERROR_DESC
-DASTORE_S_CONST_NPE=java/lang/NullPointerException
-DASTORE_S_CONST_ERROR_DESC=DASTORE npe
-AASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { env->SetObjectArrayElement((jobjectArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.l); } $trycatchhandler
-AASTORE_S_VARS=#NPE,#ERROR_DESC
-AASTORE_S_CONST_NPE=java/lang/NullPointerException
-AASTORE_S_CONST_ERROR_DESC=AASTORE npe
-BASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { utils::bastore(env, (jarray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i); } $trycatchhandler
-BASTORE_S_VARS=#NPE,#ERROR_DESC
-BASTORE_S_CONST_NPE=java/lang/NullPointerException
-BASTORE_S_CONST_ERROR_DESC=BASTORE npe
-CASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { jchar temp = (jchar) cstack$stackindexm1.i; env->SetCharArrayRegion((jcharArray) cstack$stackindexm3.l, cstack$stackindexm2.i, 1, &temp); } $trycatchhandler
-CASTORE_S_VARS=#NPE,#ERROR_DESC
-CASTORE_S_CONST_NPE=java/lang/NullPointerException
-CASTORE_S_CONST_ERROR_DESC=CASTORE npe
-SASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { jshort temp = (jshort) cstack$stackindexm1.i; env->SetShortArrayRegion((jshortArray) cstack$stackindexm3.l, cstack$stackindexm2.i, 1, &temp); } $trycatchhandler
-SASTORE_S_VARS=#NPE,#ERROR_DESC
-SASTORE_S_CONST_NPE=java/lang/NullPointerException
-SASTORE_S_CONST_ERROR_DESC=SASTORE npe
+IALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_int((jintArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "IALOAD")) { $trycatchhandler } } $trycatchhandler
+IALOAD_S_VARS=#NPE,#ERROR_DESC
+IALOAD_S_CONST_NPE=java/lang/NullPointerException
+IALOAD_S_CONST_ERROR_DESC=IALOAD npe
+LALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_long((jlongArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.j, $line, "LALOAD")) { $trycatchhandler } } $trycatchhandler
+LALOAD_S_VARS=#NPE,#ERROR_DESC
+LALOAD_S_CONST_NPE=java/lang/NullPointerException
+LALOAD_S_CONST_ERROR_DESC=LALOAD npe
+FALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_float((jfloatArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.f, $line, "FALOAD")) { $trycatchhandler } } $trycatchhandler
+FALOAD_S_VARS=#NPE,#ERROR_DESC
+FALOAD_S_CONST_NPE=java/lang/NullPointerException
+FALOAD_S_CONST_ERROR_DESC=FALOAD npe
+DALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_double((jdoubleArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.d, $line, "DALOAD")) { $trycatchhandler } } $trycatchhandler
+DALOAD_S_VARS=#NPE,#ERROR_DESC
+DALOAD_S_CONST_NPE=java/lang/NullPointerException
+DALOAD_S_CONST_ERROR_DESC=DALOAD npe
+AALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { auto __ngen_parent = (jobjectArray) cstack$stackindexm2.l; if (!object_arrays.load(__ngen_parent, cstack$stackindexm1.i, cstack$stackindexm2.l, $line, "AALOAD")) { $trycatchhandler } else { refs.insert(cstack$stackindexm2.l); } } $trycatchhandler
+AALOAD_S_VARS=#NPE,#ERROR_DESC
+AALOAD_S_CONST_NPE=java/lang/NullPointerException
+AALOAD_S_CONST_ERROR_DESC=AALOAD npe
+BALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_boolean_or_byte((jarray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "BALOAD")) { $trycatchhandler } } $trycatchhandler
+BALOAD_S_VARS=#NPE,#ERROR_DESC
+BALOAD_S_CONST_NPE=java/lang/NullPointerException
+BALOAD_S_CONST_ERROR_DESC=BALOAD npe
+CALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_char((jcharArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "CALOAD")) { $trycatchhandler } } $trycatchhandler
+CALOAD_S_VARS=#NPE,#ERROR_DESC
+CALOAD_S_CONST_NPE=java/lang/NullPointerException
+CALOAD_S_CONST_ERROR_DESC=CALOAD npe
+SALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_short((jshortArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "SALOAD")) { $trycatchhandler } } $trycatchhandler
+SALOAD_S_VARS=#NPE,#ERROR_DESC
+SALOAD_S_CONST_NPE=java/lang/NullPointerException
+SALOAD_S_CONST_ERROR_DESC=SALOAD npe
 POP=;
 POP2=;
 DUP=cstack$stackindex0 = cstack$stackindexm1;
@@ -640,3 +608,35 @@ CHECKCAST=if (cstack$stackindexm1.l != nullptr && !env->IsInstanceOf(cstack$stac
 CHECKCAST_S_VARS=#CCE,#ERROR_DESC,$desc
 CHECKCAST_S_CONST_CCE=java/lang/ClassCastException
 CHECKCAST_S_CONST_ERROR_DESC=cannot cast to 
+IASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_int((jintArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "IASTORE")) { $trycatchhandler } } $trycatchhandler
+IASTORE_S_VARS=#NPE,#ERROR_DESC
+IASTORE_S_CONST_NPE=java/lang/NullPointerException
+IASTORE_S_CONST_ERROR_DESC=IASTORE npe
+LASTORE=if (cstack$stackindexm4.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_long((jlongArray) cstack$stackindexm4.l, cstack$stackindexm3.i, cstack$stackindexm2.j, $line, "LASTORE")) { $trycatchhandler } } $trycatchhandler
+LASTORE_S_VARS=#NPE,#ERROR_DESC
+LASTORE_S_CONST_NPE=java/lang/NullPointerException
+LASTORE_S_CONST_ERROR_DESC=LASTORE npe
+FASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_float((jfloatArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.f, $line, "FASTORE")) { $trycatchhandler } } $trycatchhandler
+FASTORE_S_VARS=#NPE,#ERROR_DESC
+FASTORE_S_CONST_NPE=java/lang/NullPointerException
+FASTORE_S_CONST_ERROR_DESC=FASTORE npe
+DASTORE=if (cstack$stackindexm4.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_double((jdoubleArray) cstack$stackindexm4.l, cstack$stackindexm3.i, cstack$stackindexm2.d, $line, "DASTORE")) { $trycatchhandler } } $trycatchhandler
+DASTORE_S_VARS=#NPE,#ERROR_DESC
+DASTORE_S_CONST_NPE=java/lang/NullPointerException
+DASTORE_S_CONST_ERROR_DESC=DASTORE npe
+AASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!object_arrays.store((jobjectArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.l, $line, "AASTORE")) { $trycatchhandler } } $trycatchhandler
+AASTORE_S_VARS=#NPE,#ERROR_DESC
+AASTORE_S_CONST_NPE=java/lang/NullPointerException
+AASTORE_S_CONST_ERROR_DESC=AASTORE npe
+BASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_boolean_or_byte((jarray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "BASTORE")) { $trycatchhandler } } $trycatchhandler
+BASTORE_S_VARS=#NPE,#ERROR_DESC
+BASTORE_S_CONST_NPE=java/lang/NullPointerException
+BASTORE_S_CONST_ERROR_DESC=BASTORE npe
+CASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_char((jcharArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "CASTORE")) { $trycatchhandler } } $trycatchhandler
+CASTORE_S_VARS=#NPE,#ERROR_DESC
+CASTORE_S_CONST_NPE=java/lang/NullPointerException
+CASTORE_S_CONST_ERROR_DESC=CASTORE npe
+SASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_short((jshortArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "SASTORE")) { $trycatchhandler } } $trycatchhandler
+SASTORE_S_VARS=#NPE,#ERROR_DESC
+SASTORE_S_CONST_NPE=java/lang/NullPointerException
+SASTORE_S_CONST_ERROR_DESC=SASTORE npe

--- a/obfuscator/src/main/resources/sources/cppsnippets.properties
+++ b/obfuscator/src/main/resources/sources/cppsnippets.properties
@@ -48,35 +48,35 @@ LSTORE=clocal$var.j = cstack$stackindexm2.j;
 FSTORE=clocal$var.f = cstack$stackindexm1.f;
 DSTORE=clocal$var.d = cstack$stackindexm2.d;
 ASTORE=clocal$var.l = cstack$stackindexm1.l; refs.insert(cstack$stackindexm1.l);
-IALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_int((jintArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "IALOAD")) { $trycatchhandler } } $trycatchhandler
+IALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->load_int((jintArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "IALOAD")) { $trycatchhandler } } $trycatchhandler
 IALOAD_S_VARS=#NPE,#ERROR_DESC
 IALOAD_S_CONST_NPE=java/lang/NullPointerException
 IALOAD_S_CONST_ERROR_DESC=IALOAD npe
-LALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_long((jlongArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.j, $line, "LALOAD")) { $trycatchhandler } } $trycatchhandler
+LALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->load_long((jlongArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.j, $line, "LALOAD")) { $trycatchhandler } } $trycatchhandler
 LALOAD_S_VARS=#NPE,#ERROR_DESC
 LALOAD_S_CONST_NPE=java/lang/NullPointerException
 LALOAD_S_CONST_ERROR_DESC=LALOAD npe
-FALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_float((jfloatArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.f, $line, "FALOAD")) { $trycatchhandler } } $trycatchhandler
+FALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->load_float((jfloatArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.f, $line, "FALOAD")) { $trycatchhandler } } $trycatchhandler
 FALOAD_S_VARS=#NPE,#ERROR_DESC
 FALOAD_S_CONST_NPE=java/lang/NullPointerException
 FALOAD_S_CONST_ERROR_DESC=FALOAD npe
-DALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_double((jdoubleArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.d, $line, "DALOAD")) { $trycatchhandler } } $trycatchhandler
+DALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->load_double((jdoubleArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.d, $line, "DALOAD")) { $trycatchhandler } } $trycatchhandler
 DALOAD_S_VARS=#NPE,#ERROR_DESC
 DALOAD_S_CONST_NPE=java/lang/NullPointerException
 DALOAD_S_CONST_ERROR_DESC=DALOAD npe
-AALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { auto __ngen_parent = (jobjectArray) cstack$stackindexm2.l; if (!object_arrays.load(__ngen_parent, cstack$stackindexm1.i, cstack$stackindexm2.l, $line, "AALOAD")) { $trycatchhandler } else { refs.insert(cstack$stackindexm2.l); } } $trycatchhandler
+AALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { auto __ngen_parent = (jobjectArray) cstack$stackindexm2.l; if (!object_arrays) { object_arrays = std::make_unique<native_jvm::utils::ObjectArrayCache>(env); } if (!object_arrays->load(__ngen_parent, cstack$stackindexm1.i, cstack$stackindexm2.l, $line, "AALOAD")) { $trycatchhandler } else { refs.insert(cstack$stackindexm2.l); } } $trycatchhandler
 AALOAD_S_VARS=#NPE,#ERROR_DESC
 AALOAD_S_CONST_NPE=java/lang/NullPointerException
 AALOAD_S_CONST_ERROR_DESC=AALOAD npe
-BALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_boolean_or_byte((jarray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "BALOAD")) { $trycatchhandler } } $trycatchhandler
+BALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->load_boolean_or_byte((jarray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "BALOAD")) { $trycatchhandler } } $trycatchhandler
 BALOAD_S_VARS=#NPE,#ERROR_DESC
 BALOAD_S_CONST_NPE=java/lang/NullPointerException
 BALOAD_S_CONST_ERROR_DESC=BALOAD npe
-CALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_char((jcharArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "CALOAD")) { $trycatchhandler } } $trycatchhandler
+CALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->load_char((jcharArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "CALOAD")) { $trycatchhandler } } $trycatchhandler
 CALOAD_S_VARS=#NPE,#ERROR_DESC
 CALOAD_S_CONST_NPE=java/lang/NullPointerException
 CALOAD_S_CONST_ERROR_DESC=CALOAD npe
-SALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.load_short((jshortArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "SALOAD")) { $trycatchhandler } } $trycatchhandler
+SALOAD=if (cstack$stackindexm2.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->load_short((jshortArray) cstack$stackindexm2.l, cstack$stackindexm1.i, cstack$stackindexm2.i, $line, "SALOAD")) { $trycatchhandler } } $trycatchhandler
 SALOAD_S_VARS=#NPE,#ERROR_DESC
 SALOAD_S_CONST_NPE=java/lang/NullPointerException
 SALOAD_S_CONST_ERROR_DESC=SALOAD npe
@@ -608,35 +608,35 @@ CHECKCAST=if (cstack$stackindexm1.l != nullptr && !env->IsInstanceOf(cstack$stac
 CHECKCAST_S_VARS=#CCE,#ERROR_DESC,$desc
 CHECKCAST_S_CONST_CCE=java/lang/ClassCastException
 CHECKCAST_S_CONST_ERROR_DESC=cannot cast to 
-IASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_int((jintArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "IASTORE")) { $trycatchhandler } } $trycatchhandler
+IASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->store_int((jintArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "IASTORE")) { $trycatchhandler } } $trycatchhandler
 IASTORE_S_VARS=#NPE,#ERROR_DESC
 IASTORE_S_CONST_NPE=java/lang/NullPointerException
 IASTORE_S_CONST_ERROR_DESC=IASTORE npe
-LASTORE=if (cstack$stackindexm4.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_long((jlongArray) cstack$stackindexm4.l, cstack$stackindexm3.i, cstack$stackindexm2.j, $line, "LASTORE")) { $trycatchhandler } } $trycatchhandler
+LASTORE=if (cstack$stackindexm4.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->store_long((jlongArray) cstack$stackindexm4.l, cstack$stackindexm3.i, cstack$stackindexm2.j, $line, "LASTORE")) { $trycatchhandler } } $trycatchhandler
 LASTORE_S_VARS=#NPE,#ERROR_DESC
 LASTORE_S_CONST_NPE=java/lang/NullPointerException
 LASTORE_S_CONST_ERROR_DESC=LASTORE npe
-FASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_float((jfloatArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.f, $line, "FASTORE")) { $trycatchhandler } } $trycatchhandler
+FASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->store_float((jfloatArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.f, $line, "FASTORE")) { $trycatchhandler } } $trycatchhandler
 FASTORE_S_VARS=#NPE,#ERROR_DESC
 FASTORE_S_CONST_NPE=java/lang/NullPointerException
 FASTORE_S_CONST_ERROR_DESC=FASTORE npe
-DASTORE=if (cstack$stackindexm4.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_double((jdoubleArray) cstack$stackindexm4.l, cstack$stackindexm3.i, cstack$stackindexm2.d, $line, "DASTORE")) { $trycatchhandler } } $trycatchhandler
+DASTORE=if (cstack$stackindexm4.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->store_double((jdoubleArray) cstack$stackindexm4.l, cstack$stackindexm3.i, cstack$stackindexm2.d, $line, "DASTORE")) { $trycatchhandler } } $trycatchhandler
 DASTORE_S_VARS=#NPE,#ERROR_DESC
 DASTORE_S_CONST_NPE=java/lang/NullPointerException
 DASTORE_S_CONST_ERROR_DESC=DASTORE npe
-AASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!object_arrays.store((jobjectArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.l, $line, "AASTORE")) { $trycatchhandler } } $trycatchhandler
+AASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!object_arrays) { object_arrays = std::make_unique<native_jvm::utils::ObjectArrayCache>(env); } if (!object_arrays->store((jobjectArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.l, $line, "AASTORE")) { $trycatchhandler } } $trycatchhandler
 AASTORE_S_VARS=#NPE,#ERROR_DESC
 AASTORE_S_CONST_NPE=java/lang/NullPointerException
 AASTORE_S_CONST_ERROR_DESC=AASTORE npe
-BASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_boolean_or_byte((jarray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "BASTORE")) { $trycatchhandler } } $trycatchhandler
+BASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->store_boolean_or_byte((jarray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "BASTORE")) { $trycatchhandler } } $trycatchhandler
 BASTORE_S_VARS=#NPE,#ERROR_DESC
 BASTORE_S_CONST_NPE=java/lang/NullPointerException
 BASTORE_S_CONST_ERROR_DESC=BASTORE npe
-CASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_char((jcharArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "CASTORE")) { $trycatchhandler } } $trycatchhandler
+CASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->store_char((jcharArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "CASTORE")) { $trycatchhandler } } $trycatchhandler
 CASTORE_S_VARS=#NPE,#ERROR_DESC
 CASTORE_S_CONST_NPE=java/lang/NullPointerException
 CASTORE_S_CONST_ERROR_DESC=CASTORE npe
-SASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays.store_short((jshortArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "SASTORE")) { $trycatchhandler } } $trycatchhandler
+SASTORE=if (cstack$stackindexm3.l == nullptr) utils::throw_re(env, #NPE, #ERROR_DESC, $line); else { if (!primitive_arrays) { primitive_arrays = std::make_unique<native_jvm::utils::PrimitiveArrayCache>(env); } if (!primitive_arrays->store_short((jshortArray) cstack$stackindexm3.l, cstack$stackindexm2.i, cstack$stackindexm1.i, $line, "SASTORE")) { $trycatchhandler } } $trycatchhandler
 SASTORE_S_VARS=#NPE,#ERROR_DESC
 SASTORE_S_CONST_NPE=java/lang/NullPointerException
 SASTORE_S_CONST_ERROR_DESC=SASTORE npe

--- a/obfuscator/src/main/resources/sources/native_jvm.hpp
+++ b/obfuscator/src/main/resources/sources/native_jvm.hpp
@@ -13,7 +13,6 @@
 #include <initializer_list>
 #include <cstdint>
 #include <vector>
-#include <unordered_map>
 
 #ifndef NATIVE_JVM_HPP_GUARD
 
@@ -183,7 +182,8 @@ namespace native_jvm {
         struct ParentEntry {
             jobjectArray array;
             jsize length;
-            std::unordered_map<jint, jobject> values;
+            std::vector<jobject> values;
+            std::vector<uint8_t> cached;
             jint lastIndex;
             jobject lastValue;
             bool hasLast;

--- a/obfuscator/src/main/resources/sources/native_jvm.hpp
+++ b/obfuscator/src/main/resources/sources/native_jvm.hpp
@@ -13,6 +13,7 @@
 #include <initializer_list>
 #include <cstdint>
 #include <vector>
+#include <unordered_map>
 
 #ifndef NATIVE_JVM_HPP_GUARD
 
@@ -169,6 +170,9 @@ namespace native_jvm {
 
         JNIEnv *env;
         std::vector<Entry> entries;
+        std::unordered_map<jarray, size_t> index_map;
+        size_t last_index;
+        bool has_last;
     };
 
     class ObjectArrayCache {

--- a/obfuscator/src/main/resources/sources/native_jvm.hpp
+++ b/obfuscator/src/main/resources/sources/native_jvm.hpp
@@ -167,12 +167,15 @@ namespace native_jvm {
         Entry *ensure_entry(jarray array, Kind kind);
         bool check_index(const Entry &entry, jint index, int line, const char *opcode);
         void release_all();
+        void rebuild_index_map();
 
         JNIEnv *env;
         std::vector<Entry> entries;
         std::unordered_map<jarray, size_t> index_map;
         size_t last_index;
         bool has_last;
+        bool using_map;
+        static constexpr size_t MAP_THRESHOLD = 8;
     };
 
     class ObjectArrayCache {
@@ -196,9 +199,15 @@ namespace native_jvm {
         ParentEntry *find_parent(jobjectArray array);
         ParentEntry *ensure_parent(jobjectArray array);
         bool check_index(const ParentEntry &entry, jint index, int line, const char *opcode);
+        void rebuild_parent_index();
 
         JNIEnv *env;
         std::vector<ParentEntry> parents;
+        std::unordered_map<jobjectArray, size_t> parent_index;
+        size_t last_parent_index;
+        bool has_last_parent;
+        bool using_map;
+        static constexpr size_t MAP_THRESHOLD = 8;
     };
 
     inline uint32_t rotl32(uint32_t v, int r) {

--- a/obfuscator/src/main/resources/sources/native_jvm.hpp
+++ b/obfuscator/src/main/resources/sources/native_jvm.hpp
@@ -13,6 +13,7 @@
 #include <initializer_list>
 #include <cstdint>
 #include <vector>
+#include <unordered_map>
 
 #ifndef NATIVE_JVM_HPP_GUARD
 
@@ -179,18 +180,21 @@ namespace native_jvm {
         bool store(jobjectArray array, jint index, jobject value, int line, const char *opcode);
 
     private:
-        struct Entry {
+        struct ParentEntry {
             jobjectArray array;
-            jint index;
-            jobject value;
             jsize length;
+            std::unordered_map<jint, jobject> values;
+            jint lastIndex;
+            jobject lastValue;
+            bool hasLast;
         };
 
-        Entry *find_entry(jobjectArray array, jint index);
-        bool check_index(jsize length, jint index, int line, const char *opcode);
+        ParentEntry *find_parent(jobjectArray array);
+        ParentEntry *ensure_parent(jobjectArray array);
+        bool check_index(const ParentEntry &entry, jint index, int line, const char *opcode);
 
         JNIEnv *env;
-        std::vector<Entry> entries;
+        std::vector<ParentEntry> parents;
     };
 
     inline uint32_t rotl32(uint32_t v, int r) {

--- a/obfuscator/src/main/resources/sources/native_jvm.hpp
+++ b/obfuscator/src/main/resources/sources/native_jvm.hpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <vector>
 #include <unordered_map>
+#include <memory>
 
 #ifndef NATIVE_JVM_HPP_GUARD
 
@@ -93,8 +94,9 @@ namespace native_jvm {
     }
 
 #ifdef USE_HOTSPOT
-    jobject link_call_site(JNIEnv *env, jobject caller_obj, jobject bootstrap_method_obj,
-            jobject name_obj, jobject type_obj, jobject static_arguments, jobject appendix_result);
+    jobject link_call_site_cached(JNIEnv *env, jint class_index, jint method_index, jint site_index,
+            jobject caller_obj, jobject bootstrap_method_obj, jobject name_obj, jobject type_obj,
+            jobject static_arguments, jobject appendix_result);
 #endif
 
     jclass find_class_wo_static(JNIEnv *env, jobject classloader, jstring class_name);

--- a/perf/MatrixBench.java
+++ b/perf/MatrixBench.java
@@ -1,0 +1,109 @@
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+public class MatrixBench {
+    private static final AtomicLong BH = new AtomicLong();
+    private static final Random RANDOM = new Random(123456789L);
+
+    public static void main(String[] args) throws Exception {
+        microbenchMatrixMultiply();
+        System.out.println("=== All tests completed ===");
+    }
+
+    static void microbenchMatrixMultiply() throws Exception {
+        System.out.println("\n--- Microbench: Matrix Multiply (double) ---");
+        final int N = 32; // keep modest for quick run
+        double[][] A = new double[N][N];
+        double[][] B = new double[N][N];
+        double[][] C = new double[N][N];
+        fillRandom(A);
+        fillRandom(B);
+
+        long tSeq = timeMillis(() -> mmulSeq(A, B, C), 1, 1);
+        System.out.println("Seq:       " + tSeq + " ms");
+    }
+
+    static void mmulSeq(double[][] A, double[][] B, double[][] C) {
+        int n = A.length;
+        for (int i = 0; i < n; i++) {
+            double[] Ci = C[i];
+            for (int j = 0; j < n; j++) {
+                double sum = 0;
+                for (int k = 0; k < n; k++) {
+                    sum += A[i][k] * B[k][j];
+                }
+                Ci[j] = sum;
+            }
+        }
+        BH.addAndGet((long) C[0][0]);
+    }
+
+    static void mmulParallelStream(double[][] A, double[][] B, double[][] C) {
+        int n = A.length;
+        IntStream.range(0, n).parallel().forEach(i -> {
+            double[] Ci = C[i];
+            for (int j = 0; j < n; j++) {
+                double sum = 0;
+                for (int k = 0; k < n; k++) {
+                    sum += A[i][k] * B[k][j];
+                }
+                Ci[j] = sum;
+            }
+        });
+        BH.addAndGet((long) C[0][0]);
+    }
+
+    static void mmulVirtualThreads(double[][] A, double[][] B, double[][] C) throws Exception {
+        int n = A.length;
+        try (ExecutorService executor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory())) {
+            Future<?>[] futures = new Future<?>[n];
+            for (int i = 0; i < n; i++) {
+                final int row = i;
+                futures[i] = executor.submit(() -> {
+                    double[] Ci = C[row];
+                    for (int j = 0; j < n; j++) {
+                        double sum = 0;
+                        for (int k = 0; k < n; k++) {
+                            sum += A[row][k] * B[k][j];
+                        }
+                        Ci[j] = sum;
+                    }
+                });
+            }
+            for (Future<?> f : futures) {
+                f.get();
+            }
+        }
+        BH.addAndGet((long) C[0][0]);
+    }
+
+    static void fillRandom(double[][] matrix) {
+        for (double[] row : matrix) {
+            for (int j = 0; j < row.length; j++) {
+                row[j] = RANDOM.nextDouble();
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    static long timeMillis(ThrowingRunnable runnable, int warmup, int iterations) throws Exception {
+        for (int i = 0; i < warmup; i++) {
+            runnable.run();
+        }
+        long start = System.nanoTime();
+        for (int i = 0; i < iterations; i++) {
+            runnable.run();
+        }
+        long duration = System.nanoTime() - start;
+        return TimeUnit.NANOSECONDS.toMillis(duration);
+    }
+}


### PR DESCRIPTION
## Summary
- add a JNI-side ObjectArrayCache alongside the existing primitive cache to reuse jobjectArray elements and avoid repeated GetObjectArrayElement calls during transpiled execution.
- wire the new cache into generated method prologues and array load/store snippets and allow negating the string/constant obfuscation flags used by the CLI.
- add the MatrixBench microbenchmark to manually compare baseline and transpiled performance.

## Testing
- ./gradlew test *(fails: ClassicTest Ideal != Test)*
- java -cp perf/MatrixBench.jar MatrixBench *(baseline before obfuscation)*
- java -cp perf/out/MatrixBench.jar MatrixBench *(after obfuscation build)*

------
https://chatgpt.com/codex/tasks/task_e_68deac4fbb0c8332bb2468636baf277e